### PR TITLE
Add Ant build & release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Install JavaFX
+        run: sudo apt-get update && sudo apt-get install -y openjfx
+      - name: Build with Ant
+        run: ant -noinput jar
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/jar/FTF-Vokabeln.jar

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+# Build output
+build/

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,33 @@
+<project name="FTF-Vokabeln" default="jar" basedir=".">
+    <property name="src.dir" location="src"/>
+    <property name="build.dir" location="build"/>
+    <property name="classes.dir" location="${build.dir}/classes"/>
+    <property name="jar.dir" location="${build.dir}/jar"/>
+    <property name="jar.file" location="${jar.dir}/FTF-Vokabeln.jar"/>
+    <property name="javafx.lib" location="/usr/share/openjfx/lib"/>
+
+    <target name="clean">
+        <delete dir="${build.dir}"/>
+    </target>
+
+    <target name="compile">
+        <mkdir dir="${classes.dir}"/>
+        <javac srcdir="${src.dir}" destdir="${classes.dir}" includeantruntime="false">
+            <classpath>
+                <fileset dir="${javafx.lib}" includes="*.jar"/>
+            </classpath>
+        </javac>
+        <copy todir="${classes.dir}">
+            <fileset dir="${src.dir}" excludes="**/*.java"/>
+        </copy>
+    </target>
+
+    <target name="jar" depends="compile">
+        <mkdir dir="${jar.dir}"/>
+        <jar destfile="${jar.file}" basedir="${classes.dir}">
+            <manifest>
+                <attribute name="Main-Class" value="Main"/>
+            </manifest>
+        </jar>
+    </target>
+</project>


### PR DESCRIPTION
## Summary
- ignore `build` directory
- add an Ant build script to compile the project
- add workflow to build with Ant and create a release when tags are pushed

## Testing
- `ant jar`


------
https://chatgpt.com/codex/tasks/task_e_6841669e69e0832692bfbb3b8977d052