### PR TITLE
Add highscore board and user management

### DIFF
--- a/src/MainMenu/MainMenuController.java
+++ b/src/MainMenu/MainMenuController.java
@@ -35,6 +35,13 @@ public class MainMenuController {
     public void openSettings(ActionEvent event) {
         SceneLoader.load("/Settings/Settings.fxml");
     }
+    public void openUserManagement(ActionEvent event) {
+        SceneLoader.load("/UserManagement/UserManagement.fxml");
+    }
+
+    public void openScoreBoard(ActionEvent event) {
+        SceneLoader.load("/ScoreBoard/ScoreBoard.fxml");
+    }
 
     @FXML
     private void toggleSideMenu() {

--- a/src/MainMenu/mainMenu.fxml
+++ b/src/MainMenu/mainMenu.fxml
@@ -19,6 +19,8 @@
                   <Font name="System Bold" size="22.0" />
                </font></Label>
             <Button fx:id="button" mnemonicParsing="false" onAction="#openTrainer" text="Vokabeltrainer starten" />
+            <Button mnemonicParsing="false" onAction="#openUserManagement" text="Benutzer verwalten" />
+            <Button mnemonicParsing="false" onAction="#openScoreBoard" text="Highscore" />
             <Button fx:id="exitButton" mnemonicParsing="false" onAction="#handleExit" text="Beenden" />
          </children>
       </VBox>

--- a/src/ScoreBoard/ScoreBoard.fxml
+++ b/src/ScoreBoard/ScoreBoard.fxml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<AnchorPane xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="ScoreBoard.ScoreBoardController">
+    <children>
+        <VBox spacing="10" AnchorPane.topAnchor="10" AnchorPane.leftAnchor="10" AnchorPane.rightAnchor="10" AnchorPane.bottomAnchor="10">
+            <Label text="Highscore" />
+            <TableView fx:id="scoreTable" prefHeight="200.0">
+                <columns>
+                    <TableColumn fx:id="nameColumn" text="Name" prefWidth="150.0" />
+                    <TableColumn fx:id="pointsColumn" text="Punkte" prefWidth="80.0" />
+                </columns>
+            </TableView>
+            <Label fx:id="progressLabel" text="Fortschritt" />
+            <Button text="Zurück zum Menü" onAction="#backToMenu" />
+        </VBox>
+    </children>
+</AnchorPane>

--- a/src/ScoreBoard/ScoreBoardController.java
+++ b/src/ScoreBoard/ScoreBoardController.java
@@ -1,0 +1,75 @@
+package ScoreBoard;
+
+import Utils.SceneLoader.SceneLoader;
+import Utils.UserScore.UserSystem;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.stage.Stage;
+
+import java.net.URL;
+import java.util.ResourceBundle;
+
+public class ScoreBoardController implements Initializable, SceneLoader.HasStage {
+    @FXML
+    private TableView<UserRow> scoreTable;
+    @FXML
+    private TableColumn<UserRow, String> nameColumn;
+    @FXML
+    private TableColumn<UserRow, Integer> pointsColumn;
+    @FXML
+    private Label progressLabel;
+
+    private Stage stage;
+    private final UserSystem userSystem = UserSystem.getInstance();
+
+    @Override
+    public void setStage(Stage stage) {
+        this.stage = stage;
+    }
+
+    @Override
+    public void initialize(URL url, ResourceBundle resourceBundle) {
+        nameColumn.setCellValueFactory(new PropertyValueFactory<>("name"));
+        pointsColumn.setCellValueFactory(new PropertyValueFactory<>("points"));
+        refreshTable();
+        updateProgress();
+    }
+
+    private void refreshTable() {
+        userSystem.sortByScoreDescending();
+        ObservableList<UserRow> data = FXCollections.observableArrayList();
+        for (String name : userSystem.getAllUserNames()) {
+            data.add(new UserRow(name, userSystem.getPoints(name)));
+        }
+        scoreTable.setItems(data);
+    }
+
+    private void updateProgress() {
+        String user = userSystem.getCurrentUser();
+        int plus = userSystem.getDiffCorrect(user, null);
+        int minus = userSystem.getDiffIncorrect(user, null);
+        progressLabel.setText("Fortschritt seit letzter Runde: +" + plus + " / -" + minus);
+    }
+
+    @FXML
+    private void backToMenu() {
+        SceneLoader.load(stage, "/MainMenu/mainMenu.fxml");
+    }
+
+    public static class UserRow {
+        private final String name;
+        private final int points;
+        public UserRow(String name, int points) {
+            this.name = name;
+            this.points = points;
+        }
+        public String getName() { return name; }
+        public int getPoints() { return points; }
+    }
+}

--- a/src/UserManagement/UserManagement.fxml
+++ b/src/UserManagement/UserManagement.fxml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<AnchorPane xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="UserManagement.UserManagementController">
+    <children>
+        <VBox spacing="10" AnchorPane.topAnchor="10" AnchorPane.leftAnchor="10" AnchorPane.rightAnchor="10" AnchorPane.bottomAnchor="10">
+            <Label text="Benutzerverwaltung" />
+            <HBox spacing="5">
+                <TextField fx:id="newUserField" promptText="Name" />
+                <Button text="Erstellen" onAction="#createUser" />
+            </HBox>
+            <HBox spacing="5">
+                <TextField fx:id="searchField" promptText="Suchen" />
+                <Button text="Auswählen" onAction="#selectUser" />
+            </HBox>
+            <ListView fx:id="userList" prefHeight="200.0" />
+            <Button text="Zurück" onAction="#backToMenu" />
+        </VBox>
+    </children>
+</AnchorPane>

--- a/src/UserManagement/UserManagementController.java
+++ b/src/UserManagement/UserManagementController.java
@@ -1,0 +1,74 @@
+package UserManagement;
+
+import Utils.SceneLoader.SceneLoader;
+import Utils.UserScore.UserSystem;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.control.Button;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TextField;
+import javafx.stage.Stage;
+
+import java.net.URL;
+import java.util.ResourceBundle;
+
+public class UserManagementController implements Initializable, SceneLoader.HasStage {
+    @FXML
+    private TextField newUserField;
+    @FXML
+    private TextField searchField;
+    @FXML
+    private ListView<String> userList;
+    @FXML
+    private Button backButton;
+
+    private Stage stage;
+    private final UserSystem userSystem = UserSystem.getInstance();
+
+    @Override
+    public void setStage(Stage stage) {
+        this.stage = stage;
+    }
+
+    @Override
+    public void initialize(URL url, ResourceBundle resourceBundle) {
+        userSystem.loadFromFile();
+        refreshList("");
+        searchField.textProperty().addListener((obs, o, n) -> refreshList(n));
+    }
+
+    @FXML
+    private void createUser() {
+        String name = newUserField.getText().trim();
+        if (!name.isEmpty()) {
+            userSystem.addUser(name);
+            userSystem.setCurrentUser(name);
+            userSystem.saveToFile();
+            refreshList(searchField.getText().trim());
+            newUserField.clear();
+        }
+    }
+
+    @FXML
+    private void selectUser() {
+        String selected = userList.getSelectionModel().getSelectedItem();
+        if (selected != null) {
+            userSystem.setCurrentUser(selected);
+            userSystem.saveToFile();
+        }
+    }
+
+    private void refreshList(String filter) {
+        userList.getItems().clear();
+        for (String name : userSystem.getAllUserNames()) {
+            if (filter == null || filter.isBlank() || name.toLowerCase().contains(filter.toLowerCase())) {
+                userList.getItems().add(name);
+            }
+        }
+    }
+
+    @FXML
+    private void backToMenu() {
+        SceneLoader.load(stage, "/MainMenu/mainMenu.fxml");
+    }
+}

--- a/src/Utils/UserScore/UserSystem.java
+++ b/src/Utils/UserScore/UserSystem.java
@@ -10,6 +10,15 @@ import java.util.*;
  */
 public class UserSystem {
 
+    // Singleton instance
+    private static final UserSystem INSTANCE = new UserSystem();
+
+    public static UserSystem getInstance() {
+        return INSTANCE;
+    }
+
+    private String currentUser = "user";
+
     // Standardliste, falls keine Liste spezifiziert wurde
     private static final String DEFAULT_LIST = "default";
 
@@ -157,8 +166,22 @@ public class UserSystem {
         return null;
     }
 
+    public boolean userExists(String name) {
+        return getUserByName(name) != null;
+    }
+
     private User getUserByIndex(int index) {
         return (index >= 0 && index < users.size()) ? users.get(index) : null;
+    }
+
+    public String getCurrentUser() {
+        return currentUser;
+    }
+
+    public void setCurrentUser(String name) {
+        if (userExists(name)) {
+            currentUser = name;
+        }
     }
 
     // Punktestandverwaltung
@@ -197,6 +220,26 @@ public class UserSystem {
         List<Integer> scores = new ArrayList<>();
         for (User u : users) scores.add(u.points);
         return scores;
+    }
+
+    public int getDiffCorrect(String name, String listId) {
+        VocabStats stats = getStatsForUser(name, listId);
+        return stats != null ? stats.getDiffCorrect() : 0;
+    }
+
+    public int getDiffIncorrect(String name, String listId) {
+        VocabStats stats = getStatsForUser(name, listId);
+        return stats != null ? stats.getDiffIncorrect() : 0;
+    }
+
+    public int getTotalCorrect(String name, String listId) {
+        VocabStats stats = getStatsForUser(name, listId);
+        return stats != null ? stats.correct : 0;
+    }
+
+    public int getTotalIncorrect(String name, String listId) {
+        VocabStats stats = getStatsForUser(name, listId);
+        return stats != null ? stats.incorrect : 0;
     }
 
     // Sortierung und Highscore


### PR DESCRIPTION
## Summary
- integrate singleton `UserSystem` with current user management and progress helpers
- update main menu with buttons to manage users and show highscore
- add user management screen for creating and selecting users
- add highscore board displaying scores and last session progress
- respect vocabulary mode from settings and show results screen at end of training

## Testing
- `ant jar`

------
https://chatgpt.com/codex/tasks/task_e_68416804ba148326a622c0acf6369b69