### PR TITLE
Add automatic openjfx installation

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,11 +6,33 @@
     <property name="jar.file" location="${jar.dir}/FTF-Vokabeln.jar"/>
     <property name="javafx.lib" location="/usr/share/openjfx/lib"/>
 
+    <!-- Install JavaFX automatically if it's missing -->
+    <target name="install-openjfx">
+        <!-- check if JavaFX libs are already present -->
+        <available file="${javafx.lib}" type="dir" property="javafx.present"/>
+        <echo message="JavaFX not found. Attempting to install via apt-get..." unless="javafx.present"/>
+        <exec executable="sudo" failonerror="false" unless="javafx.present">
+            <arg value="apt-get"/>
+            <arg value="update"/>
+        </exec>
+        <exec executable="sudo" failonerror="false" unless="javafx.present">
+            <arg value="apt-get"/>
+            <arg value="install"/>
+            <arg value="-y"/>
+            <arg value="openjfx"/>
+        </exec>
+        <!-- re-check after attempted installation -->
+        <available file="${javafx.lib}" type="dir" property="javafx.present"/>
+    </target>
+
     <target name="clean">
         <delete dir="${build.dir}"/>
     </target>
 
-    <target name="compile">
+    <target name="compile" depends="install-openjfx">
+        <fail unless="javafx.present">
+            JavaFX library not found at ${javafx.lib}. Please install openjfx manually.
+        </fail>
         <mkdir dir="${classes.dir}"/>
         <javac srcdir="${src.dir}" destdir="${classes.dir}" includeantruntime="false">
             <classpath>


### PR DESCRIPTION
## Summary
- add an `install-openjfx` target to install JavaFX automatically
- fail compilation if the library is still missing

## Testing
- `ant -noinput -buildfile build.xml jar` *(fails: `bash: ant: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68416d59969c8326863839c36332d55e