### PR TITLE
Add combined build and release workflow

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,0 +1,45 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [ "master" ]
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Install JavaFX
+        run: sudo apt-get update && sudo apt-get install -y openjfx
+      - name: Build with Ant
+        run: ant -noinput -buildfile build.xml
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Install JavaFX
+        run: sudo apt-get update && sudo apt-get install -y openjfx
+      - name: Build JAR
+        run: ant -noinput jar
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/jar/FTF-Vokabeln.jar
+


### PR DESCRIPTION
## Summary
- add build_and_release.yml workflow that builds on pushes and releases jars on tag pushes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841781e0c708326ad2bc5e114cf926a