### PR TITLE
Add username field on main menu

### DIFF
--- a/src/MainMenu/MainMenuController.java
+++ b/src/MainMenu/MainMenuController.java
@@ -4,8 +4,10 @@ import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
+import javafx.scene.control.TextField;
 import javafx.scene.layout.VBox;
 import Utils.SceneLoader.SceneLoader;
+import Utils.UserScore.UserSystem;
 import Utils.StageAwareController;
 
 /**
@@ -18,13 +20,25 @@ public class MainMenuController extends StageAwareController {
     private Button button;
 
     @FXML
+    private TextField userField;
+
+    @FXML
     private VBox sideMenu;
+
+    @FXML
+    private void initialize() {
+        UserSystem.loadFromFile();
+        if (userField != null) {
+            userField.setText(UserSystem.getCurrentUser());
+        }
+    }
 
     @FXML
     /**
      * Öffnet den eigentlichen Trainer.
      */
     public void openTrainer(ActionEvent event) {
+        prepareUser();
         SceneLoader.load("/Trainer/Trainer.fxml");
     }
     /**
@@ -45,6 +59,7 @@ public class MainMenuController extends StageAwareController {
      * Zeigt die Highscore-Tabelle an.
      */
     public void openScoreBoard(ActionEvent event) {
+        prepareUser();
         SceneLoader.load("/ScoreBoard/ScoreBoard.fxml");
     }
 
@@ -64,5 +79,20 @@ public class MainMenuController extends StageAwareController {
     @FXML
     private void handleExit() {
         Platform.exit();
+    }
+
+    private void prepareUser() {
+        if (userField == null) {
+            return;
+        }
+        String name = userField.getText().trim();
+        if (name.isEmpty()) {
+            name = "user";
+        }
+        if (!UserSystem.userExists(name)) {
+            UserSystem.addUser(name);
+        }
+        UserSystem.setCurrentUser(name);
+        UserSystem.saveToFile();
     }
 }

--- a/src/MainMenu/mainMenu.fxml
+++ b/src/MainMenu/mainMenu.fxml
@@ -17,7 +17,9 @@
             <Label alignment="TOP_CENTER" text="Vokabeltrainer" underline="true">
                <font>
                   <Font name="System Bold" size="22.0" />
-               </font></Label>
+               </font>
+            </Label>
+            <TextField fx:id="userField" promptText="Benutzername" />
             <Button fx:id="button" mnemonicParsing="false" onAction="#openTrainer" text="Vokabeltrainer starten" />
             <Button mnemonicParsing="false" onAction="#openUserManagement" text="Benutzer verwalten" />
             <Button mnemonicParsing="false" onAction="#openScoreBoard" text="Highscore" />


### PR DESCRIPTION
## Summary
- let user enter a name on the main menu
- use the entered name when opening the trainer or scoreboard
- automatically create/save the user in `user_data.csv`

## Testing
- `ant -noinput`

------
https://chatgpt.com/codex/tasks/task_e_6841fce68990832689c4518e79544dba