### PR TITLE
Add interactive documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ java -jar build/jar/FTF-Vokabeln.jar
 
 ## Dokumentation
 
-In `docs/Methodenliste.md` sind die wichtigsten Methoden kurz beschrieben.
+Ausführliche Erläuterungen zu Aufbau und Funktionsweise finden sich in
+[`docs/Dokumentation.md`](docs/Dokumentation.md). Eine interaktive HTML-Version
+steht unter [`docs/index.html`](docs/index.html). Eine kurze Übersicht der
+wichtigsten Methoden steht in `docs/Methodenliste.md`.
 
 ## Mitwirken
 

--- a/docs/Dokumentation.md
+++ b/docs/Dokumentation.md
@@ -1,0 +1,108 @@
+# Projektbeschreibung
+
+**FTF-Vokabeln** ist ein Vokabeltrainer basierend auf JavaFX. Das Programm entstand im Rahmen eines Schulprojekts und erlaubt das Üben und Abfragen englischer und deutscher Begriffe. Diese Dokumentation gibt einen Überblick über Aufbau und Funktionsweise des Projekts.
+
+## Inhaltsverzeichnis
+
+1. [Überblick](#überblick)
+2. [Projektstruktur](#projektstruktur)
+3. [Build und Ausführung](#build-und-ausführung)
+4. [Oberflächen und Controller](#oberflächen-und-controller)
+5. [Benutzersystem](#benutzersystem)
+6. [Training](#training)
+7. [ScoreBoard](#scoreboard)
+8. [Einstellungen](#einstellungen)
+9. [GitHub Pages einrichten](#github-pages-einrichten)
+
+## Überblick
+
+Das Programm bietet ein Hauptmenü mit Zugriff auf Training, Einstellungen, Benutzerverwaltung und Highscore-Anzeige. Vokabeln werden aus einer fest hinterlegten Liste im `TrainerModel` geladen. Für jeden Benutzer merkt sich das Programm den Punktestand sowie detaillierte Statistiken, die in einer CSV-Datei gespeichert werden.
+
+## Projektstruktur
+
+```
+FTF-Vokabeln/
+├── build.xml            Ant-Buildskript
+├── docs/                Dokumentation
+├── src/                 Quellcode und Ressourcen
+│   ├── Main.java        Einstiegspunkt
+│   ├── MainMenu/        Hauptmenü
+│   ├── Trainer/         Logik und Oberfläche des Trainings
+│   ├── ScoreBoard/      Highscore-Anzeige
+│   ├── Settings/        Einstellungen
+│   ├── UserManagement/  Benutzerverwaltung
+│   └── Utils/           Hilfsklassen
+```
+
+Die CSS- und FXML-Dateien liegen jeweils im gleichen Unterordner wie die zugehörigen Controller.
+
+## Build und Ausführung
+
+Vorausgesetzt werden JDK 11, JavaFX und Ant. Das Projekt kann über das beiliegende `build.xml` kompiliert werden:
+
+```bash
+sudo apt-get update && sudo apt-get install -y ant openjdk-11-jdk openjfx
+ant jar
+java -jar build/jar/FTF-Vokabeln.jar
+```
+
+Alternativ lässt sich der Code in jeder IDE mit JavaFX-Unterstützung starten. `Main.java` enthält den Einstiegspunkt.
+
+## Oberflächen und Controller
+
+### SceneLoader und StageAwareController
+
+Alle Szenen werden über die Hilfsklasse `SceneLoader` geladen. Sie setzt die Stage, lädt die gewünschte FXML-Datei und bindet optional ein passendes CSS ein. Controller können von `StageAwareController` erben, um die Stage automatisch zu erhalten.
+
+### MainMenuController
+
+* Zeigt das Hauptmenü an
+* Kann Training, Einstellungen, Benutzerverwaltung und ScoreBoard öffnen
+* Speichert den aktuell gewählten Benutzer mittels `UserSystem`
+
+### UserManagementController
+
+* Listet alle vorhandenen Benutzer auf
+* Neuer Benutzer kann erstellt und anschließend ausgewählt werden
+* Änderungen werden in `user_data.csv` gespeichert
+
+## Benutzersystem
+
+Das `UserSystem` verwaltet alle Benutzer samt Punkteständen. Es nutzt ausschließlich statische Methoden und speichert die Daten in `src/Utils/UserScore/user_data.csv`. Zu jeder Vokabelliste wird eine Statistik geführt. Wichtige Funktionen:
+
+* `addUser`, `removeUser`, `getAllUserNames`
+* Punktestand über `addPoint` und `getPoints`
+* Aufzeichnen von Antworten über `recordAnswer`
+* Sortieren nach Punkten (`sortByScoreDescending`)
+* Laden und Speichern der Daten mit `loadFromFile` und `saveToFile`
+
+## Training
+
+Der `TrainerController` steuert den Ablauf des Trainings:
+
+1. Beim Start wird der aktuelle Benutzer geladen und eine neue Sitzung begonnen.
+2. Abhängig vom in den Einstellungen gewählten Modus (Deutsch→Englisch, Englisch→Deutsch, Zufällig) werden Vokabeln aus dem `TrainerModel` gewählt.
+3. `loadNextVocabSet` baut dynamisch Eingabefelder auf und merkt sich die korrekten Lösungen.
+4. `checkAnswers` vergleicht die Eingaben mit der Lösung, färbt richtige und falsche Buchstaben ein und aktualisiert den Punktestand über `UserSystem`.
+5. Nach einer kurzen Pause wird das nächste Set geladen oder das ScoreBoard geöffnet.
+
+Soundeffekte werden über `SoundModel` abgespielt.
+
+## ScoreBoard
+
+`ScoreBoardController` zeigt alle Benutzer sortiert nach Punkten an und informiert über den Fortschritt der aktuellen Sitzung. Die Daten werden direkt aus dem `UserSystem` geladen.
+
+## Einstellungen
+
+Im `SettingsController` wählt der Nutzer den gewünschten Vokabelmodus aus. Die Auswahl wird über `java.util.prefs.Preferences` gespeichert und beim nächsten Start wieder geladen.
+
+## GitHub Pages einrichten
+
+Die Markdown-Dokumente im Ordner `docs` können leicht über GitHub Pages veröffentlicht werden:
+
+1. Im Repository auf **Settings → Pages** gehen.
+2. Als Quelle den Branch `main` (oder `master`) und das Verzeichnis `\docs` wählen.
+3. Nach dem Speichern stellt GitHub eine URL bereit, unter der diese Dateien als HTML abrufbar sind.
+
+Auf diese Weise lässt sich die Datei `docs/Dokumentation.md` direkt als Webseite aufrufen.
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>FTF-Vokabeln Dokumentation</title>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin:0; }
+    #sidebar { position: fixed; top:0; left:0; width: 250px; height:100%; overflow:auto; background:#f7f7f7; padding:1em; box-shadow:2px 0 5px rgba(0,0,0,0.1); }
+    #content { margin-left:260px; padding:1em; }
+    pre, code { background:#eee; padding:2px 4px; }
+    input[type="text"]{ width:100%; padding:0.3em; margin-bottom:0.5em; box-sizing:border-box; }
+    .highlight { background: yellow; }
+  </style>
+</head>
+<body>
+<div id="sidebar">
+  <h2>Inhalt</h2>
+  <input type="text" id="search" placeholder="Suche..." />
+  <div id="toc"></div>
+</div>
+<div id="content">Lade Dokumentation...</div>
+<script>
+marked.setOptions({headerIds: true});
+fetch('Dokumentation.md')
+  .then(res => res.text())
+  .then(text => {
+    const html = marked.parse(text);
+    const content = document.getElementById('content');
+    content.innerHTML = html;
+    buildToc();
+  });
+function buildToc() {
+  const toc = document.getElementById('toc');
+  const headings = document.querySelectorAll('#content h1, #content h2');
+  headings.forEach(h => {
+    const a = document.createElement('a');
+    a.textContent = h.textContent;
+    a.href = '#' + h.id;
+    a.style.display = 'block';
+    a.style.marginLeft = h.tagName === 'H2' ? '1em' : '0';
+    toc.appendChild(a);
+  });
+}
+const searchInput = document.getElementById('search');
+searchInput.addEventListener('input', () => {
+  const q = searchInput.value.toLowerCase();
+  document.querySelectorAll('#content p, #content li').forEach(el => {
+    const text = el.textContent.toLowerCase();
+    if (q && text.includes(q)) {
+      el.classList.add('highlight');
+    } else {
+      el.classList.remove('highlight');
+    }
+  });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link new interactive documentation in README
- create `docs/index.html` that loads Markdown and provides a search box

## Testing
- `ant jar`


------
https://chatgpt.com/codex/tasks/task_e_6842bc9510b48326871ae2d8dc52a0ce