### PR TITLE
Improve documentation website layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ java -jar build/jar/FTF-Vokabeln.jar
 
 ## Dokumentation
 
-In `docs/Methodenliste.md` sind die wichtigsten Methoden kurz beschrieben.
+Ausführliche Erläuterungen zu Aufbau und Funktionsweise bietet die interaktive Dokumentation unter [`docs/index.html`](docs/index.html). Eine kurze Übersicht der wichtigsten Methoden steht in `docs/Methodenliste.md`.
 
 ## Mitwirken
 

--- a/docs/Dokumentation.md
+++ b/docs/Dokumentation.md
@@ -1,0 +1,99 @@
+# Projektbeschreibung
+
+**FTF-Vokabeln** ist ein Vokabeltrainer basierend auf JavaFX. Das Programm entstand im Rahmen eines Schulprojekts und erlaubt das Üben und Abfragen englischer und deutscher Begriffe. Diese Dokumentation gibt einen Überblick über Aufbau und Funktionsweise des Projekts.
+
+## Inhaltsverzeichnis
+
+1. [Überblick](#überblick)
+2. [Projektstruktur](#projektstruktur)
+3. [Build und Ausführung](#build-und-ausführung)
+4. [Oberflächen und Controller](#oberflächen-und-controller)
+5. [Benutzersystem](#benutzersystem)
+6. [Training](#training)
+7. [ScoreBoard](#scoreboard)
+8. [Einstellungen](#einstellungen)
+
+## Überblick
+
+Das Programm bietet ein Hauptmenü mit Zugriff auf Training, Einstellungen, Benutzerverwaltung und Highscore-Anzeige. Vokabeln werden aus einer fest hinterlegten Liste im `TrainerModel` geladen. Für jeden Benutzer merkt sich das Programm den Punktestand sowie detaillierte Statistiken, die in einer CSV-Datei gespeichert werden.
+
+## Projektstruktur
+
+```
+FTF-Vokabeln/
+├── build.xml            Ant-Buildskript
+├── docs/                Dokumentation
+├── src/                 Quellcode und Ressourcen
+│   ├── Main.java        Einstiegspunkt
+│   ├── MainMenu/        Hauptmenü
+│   ├── Trainer/         Logik und Oberfläche des Trainings
+│   ├── ScoreBoard/      Highscore-Anzeige
+│   ├── Settings/        Einstellungen
+│   ├── UserManagement/  Benutzerverwaltung
+│   └── Utils/           Hilfsklassen
+```
+
+Die CSS- und FXML-Dateien liegen jeweils im gleichen Unterordner wie die zugehörigen Controller.
+
+## Build und Ausführung
+
+Vorausgesetzt werden JDK 11, JavaFX und Ant. Das Projekt kann über das beiliegende `build.xml` kompiliert werden:
+
+```bash
+sudo apt-get update && sudo apt-get install -y ant openjdk-11-jdk openjfx
+ant jar
+java -jar build/jar/FTF-Vokabeln.jar
+```
+
+Alternativ lässt sich der Code in jeder IDE mit JavaFX-Unterstützung starten. `Main.java` enthält den Einstiegspunkt.
+
+## Oberflächen und Controller
+
+### SceneLoader und StageAwareController
+
+Alle Szenen werden über die Hilfsklasse `SceneLoader` geladen. Sie setzt die Stage, lädt die gewünschte FXML-Datei und bindet optional ein passendes CSS ein. Controller können von `StageAwareController` erben, um die Stage automatisch zu erhalten.
+
+### MainMenuController
+
+* Zeigt das Hauptmenü an
+* Kann Training, Einstellungen, Benutzerverwaltung und ScoreBoard öffnen
+* Speichert den aktuell gewählten Benutzer mittels `UserSystem`
+
+### UserManagementController
+
+* Listet alle vorhandenen Benutzer auf
+* Neuer Benutzer kann erstellt und anschließend ausgewählt werden
+* Änderungen werden in `user_data.csv` gespeichert
+
+## Benutzersystem
+
+Das `UserSystem` verwaltet alle Benutzer samt Punkteständen. Es nutzt ausschließlich statische Methoden und speichert die Daten in `src/Utils/UserScore/user_data.csv`. Zu jeder Vokabelliste wird eine Statistik geführt. Wichtige Funktionen:
+
+* `addUser`, `removeUser`, `getAllUserNames`
+* Punktestand über `addPoint` und `getPoints`
+* Aufzeichnen von Antworten über `recordAnswer`
+* Sortieren nach Punkten (`sortByScoreDescending`)
+* Laden und Speichern der Daten mit `loadFromFile` und `saveToFile`
+
+## Training
+
+Der `TrainerController` steuert den Ablauf des Trainings:
+
+1. Beim Start wird der aktuelle Benutzer geladen und eine neue Sitzung begonnen.
+2. Abhängig vom in den Einstellungen gewählten Modus (Deutsch→Englisch, Englisch→Deutsch, Zufällig) werden Vokabeln aus dem `TrainerModel` gewählt.
+3. `loadNextVocabSet` baut dynamisch Eingabefelder auf und merkt sich die korrekten Lösungen.
+4. `checkAnswers` vergleicht die Eingaben mit der Lösung, färbt richtige und falsche Buchstaben ein und aktualisiert den Punktestand über `UserSystem`.
+5. Nach einer kurzen Pause wird das nächste Set geladen oder das ScoreBoard geöffnet.
+
+Soundeffekte werden über `SoundModel` abgespielt.
+
+## ScoreBoard
+
+`ScoreBoardController` zeigt alle Benutzer sortiert nach Punkten an und informiert über den Fortschritt der aktuellen Sitzung. Die Daten werden direkt aus dem `UserSystem` geladen.
+
+## Einstellungen
+
+Im `SettingsController` wählt der Nutzer den gewünschten Vokabelmodus aus. Die Auswahl wird über `java.util.prefs.Preferences` gespeichert und beim nächsten Start wieder geladen.
+
+
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>FTF-Vokabeln Dokumentation</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+<div id="sidebar">
+  <h2>Inhalt</h2>
+  <input type="text" id="search" placeholder="Suche..." />
+  <div id="toc"></div>
+</div>
+<div id="content">Lade Dokumentation...</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,145 @@
+document.addEventListener('DOMContentLoaded', () => {
+    marked.setOptions({ headerIds: true });
+    const markdown = `
+# Projektbeschreibung
+
+**FTF-Vokabeln** ist ein Vokabeltrainer basierend auf JavaFX. Das Programm entstand im Rahmen eines Schulprojekts und erlaubt das Üben und Abfragen englischer und deutscher Begriffe. Diese Dokumentation gibt einen Überblick über Aufbau und Funktionsweise des Projekts.
+
+## Inhaltsverzeichnis
+
+1. [Überblick](#überblick)
+2. [Projektstruktur](#projektstruktur)
+3. [Build und Ausführung](#build-und-ausf\u00fchrung)
+4. [Oberfl\u00e4chen und Controller](#oberfl\u00e4chen-und-controller)
+5. [Benutzersystem](#benutzersystem)
+6. [Training](#training)
+7. [ScoreBoard](#scoreboard)
+8. [Einstellungen](#einstellungen)
+
+## \u00dcberblick
+
+Das Programm bietet ein Hauptmen\u00fc mit Zugriff auf Training, Einstellungen, Benutzerverwaltung und Highscore-Anzeige. Vokabeln werden aus einer fest hinterlegten Liste im \`TrainerModel\` geladen. F\u00fcr jeden Benutzer merkt sich das Programm den Punktestand sowie detaillierte Statistiken, die in einer CSV-Datei gespeichert werden.
+
+## Projektstruktur
+
+```
+FTF-Vokabeln/
+├── build.xml            Ant-Buildskript
+├── docs/                Dokumentation
+├── src/                 Quellcode und Ressourcen
+│   ├── Main.java        Einstiegspunkt
+│   ├── MainMenu/        Hauptmen\u00fc
+│   ├── Trainer/         Logik und Oberfl\u00e4che des Trainings
+│   ├── ScoreBoard/      Highscore-Anzeige
+│   ├── Settings/        Einstellungen
+│   ├── UserManagement/  Benutzerverwaltung
+│   └── Utils/           Hilfsklassen
+```
+
+Die CSS- und FXML-Dateien liegen jeweils im gleichen Unterordner wie die zugeh\u00f6rigen Controller.
+
+## Build und Ausf\u00fchrung
+
+Vorausgesetzt werden JDK\u00a011, JavaFX und Ant. Das Projekt kann \u00fcber das beiliegende \`build.xml\` kompiliert werden:
+
+```bash
+sudo apt-get update && sudo apt-get install -y ant openjdk-11-jdk openjfx
+ant jar
+java -jar build/jar/FTF-Vokabeln.jar
+```
+
+Alternativ l\u00e4sst sich der Code in jeder IDE mit JavaFX-Unterst\u00fctzung starten. \`Main.java\` enth\u00e4lt den Einstiegspunkt.
+
+## Oberfl\u00e4chen und Controller
+
+### SceneLoader und StageAwareController
+
+Alle Szenen werden \u00fcber die Hilfsklasse \`SceneLoader\` geladen. Sie setzt die Stage, l\u00e4dt die gew\u00fcnschte FXML-Datei und bindet optional ein passendes CSS ein. Controller k\u00f6nnen von \`StageAwareController\` erben, um die Stage automatisch zu erhalten.
+
+### MainMenuController
+
+* Zeigt das Hauptmen\u00fc an
+* Kann Training, Einstellungen, Benutzerverwaltung und ScoreBoard \u00f6ffnen
+* Speichert den aktuell gew\u00e4hlten Benutzer mittels \`UserSystem\`
+
+### UserManagementController
+
+* Listet alle vorhandenen Benutzer auf
+* Neuer Benutzer kann erstellt und anschlie\u00dfend ausgew\u00e4hlt werden
+* \u00c4nderungen werden in \`user_data.csv\` gespeichert
+
+## Benutzersystem
+
+Das \`UserSystem\` verwaltet alle Benutzer samt Punktest\u00e4nden. Es nutzt ausschlie\u00dflich statische Methoden und speichert die Daten in \`src/Utils/UserScore/user_data.csv\`. Zu jeder Vokabelliste wird eine Statistik gef\u00fchrt. Wichtige Funktionen:
+
+* \`addUser\`, \`removeUser\`, \`getAllUserNames\`
+* Punktestand \u00fcber \`addPoint\` und \`getPoints\`
+* Aufzeichnen von Antworten \u00fcber \`recordAnswer\`
+* Sortieren nach Punkten (\`sortByScoreDescending\`)
+* Laden und Speichern der Daten mit \`loadFromFile\` und \`saveToFile\`
+
+## Training
+
+Der \`TrainerController\` steuert den Ablauf des Trainings:
+
+1. Beim Start wird der aktuelle Benutzer geladen und eine neue Sitzung begonnen.
+2. Abh\u00e4ngig vom in den Einstellungen gew\u00e4hlten Modus (Deutsch\u2192Englisch, Englisch\u2192Deutsch, Zuf\u00e4llig) werden Vokabeln aus dem \`TrainerModel\` gew\u00e4hlt.
+3. \`loadNextVocabSet\` baut dynamisch Eingabefelder auf und merkt sich die korrekten L\u00f6sungen.
+4. \`checkAnswers\` vergleicht die Eingaben mit der L\u00f6sung, f\u00e4rbt richtige und falsche Buchstaben ein und aktualisiert den Punktestand \u00fcber \`UserSystem\`.
+5. Nach einer kurzen Pause wird das n\u00e4chste Set geladen oder das ScoreBoard ge\u00f6ffnet.
+
+Soundeffekte werden \u00fcber \`SoundModel\` abgespielt.
+
+## ScoreBoard
+
+\`ScoreBoardController\` zeigt alle Benutzer sortiert nach Punkten an und informiert \u00fcber den Fortschritt der aktuellen Sitzung. Die Daten werden direkt aus dem \`UserSystem\` geladen.
+
+## Einstellungen
+
+Im \`SettingsController\` w\u00e4hlt der Nutzer den gew\u00fcnschten Vokabelmodus aus. Die Auswahl wird \u00fcber \`java.util.prefs.Preferences\` gespeichert und beim n\u00e4chsten Start wieder geladen.
+`;
+    const html = marked.parse(markdown);
+    document.getElementById('content').innerHTML = html;
+    buildTree();
+
+    const searchInput = document.getElementById('search');
+    searchInput.addEventListener('input', () => {
+        const q = searchInput.value.toLowerCase();
+        document.querySelectorAll('#content p, #content li').forEach(el => {
+            const text = el.textContent.toLowerCase();
+            if (q && text.includes(q)) el.classList.add('highlight');
+            else el.classList.remove('highlight');
+        });
+    });
+});
+
+function buildTree() {
+    const toc = document.getElementById('toc');
+    const stack = [{ level: 0, ul: toc }];
+    document.querySelectorAll('#content h1, #content h2, #content h3').forEach(h => {
+        const level = parseInt(h.tagName.substring(1));
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.textContent = h.textContent;
+        a.href = '#' + h.id;
+        li.appendChild(a);
+        while (stack.length > level) stack.pop();
+        let parent = stack[stack.length - 1];
+        if (!parent.ul) {
+            parent.ul = document.createElement('ul');
+            parent.li.appendChild(parent.ul);
+        }
+        parent.ul.appendChild(li);
+        stack.push({ level: level, li: li });
+    });
+    document.querySelectorAll('#toc li').forEach(li => {
+        if (li.querySelector('ul')) {
+            li.classList.add('collapsed');
+            li.addEventListener('click', e => {
+                if (e.target.tagName !== 'A') {
+                    li.classList.toggle('collapsed');
+                }
+            });
+        }
+    });
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,63 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    background: #121212;
+    color: #ddd;
+}
+
+a { color: #8ab4f8; }
+
+#sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 260px;
+    height: 100%;
+    overflow: auto;
+    background: #1e1e1e;
+    padding: 1em;
+    box-shadow: 2px 0 5px rgba(0,0,0,0.3);
+}
+
+#content {
+    margin-left: 270px;
+    padding: 1em;
+}
+
+pre, code {
+    background: #2b2b2b;
+    padding: 2px 4px;
+}
+
+input[type="text"] {
+    width: 100%;
+    padding: 0.3em;
+    margin-bottom: 0.5em;
+    box-sizing: border-box;
+    background: #333;
+    border: 1px solid #555;
+    color: #ddd;
+}
+
+.highlight {
+    background: #444;
+}
+
+#toc ul {
+    list-style: none;
+    padding-left: 1em;
+}
+
+#toc li {
+    cursor: pointer;
+    margin: 0.2em 0;
+}
+
+#toc li.collapsed > ul {
+    display: none;
+}
+
+#toc a {
+    color: inherit;
+    text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- split docs index into HTML, CSS and JS files
- keep documentation text embedded inside the JS
- add dark mode styling and collapsible tree navigation

## Testing
- `ant jar` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bc9510b48326871ae2d8dc52a0ce