### PR TITLE
Fix docs viewer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,8 @@
     <h2>Inhalt</h2>
     <input type="text" id="search" placeholder="Suche..." />
     <div id="toc"></div>
+    <hr>
+    <a href="Methodenliste.md" target="_blank">Methodenübersicht</a>
   </div>
   <div id="content">Lade Dokumentation...</div>
   <script src="script.js"></script>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,106 +1,13 @@
+
 document.addEventListener('DOMContentLoaded', () => {
     marked.setOptions({ headerIds: true });
-    const markdown = `
-# Projektbeschreibung
-
-**FTF-Vokabeln** ist ein Vokabeltrainer basierend auf JavaFX. Das Programm entstand im Rahmen eines Schulprojekts und erlaubt das Üben und Abfragen englischer und deutscher Begriffe. Diese Dokumentation gibt einen Überblick über Aufbau und Funktionsweise des Projekts.
-
-## Inhaltsverzeichnis
-
-1. [Überblick](#überblick)
-2. [Projektstruktur](#projektstruktur)
-3. [Build und Ausführung](#build-und-ausf\u00fchrung)
-4. [Oberfl\u00e4chen und Controller](#oberfl\u00e4chen-und-controller)
-5. [Benutzersystem](#benutzersystem)
-6. [Training](#training)
-7. [ScoreBoard](#scoreboard)
-8. [Einstellungen](#einstellungen)
-
-## \u00dcberblick
-
-Das Programm bietet ein Hauptmen\u00fc mit Zugriff auf Training, Einstellungen, Benutzerverwaltung und Highscore-Anzeige. Vokabeln werden aus einer fest hinterlegten Liste im \`TrainerModel\` geladen. F\u00fcr jeden Benutzer merkt sich das Programm den Punktestand sowie detaillierte Statistiken, die in einer CSV-Datei gespeichert werden.
-
-## Projektstruktur
-
-```
-FTF-Vokabeln/
-├── build.xml            Ant-Buildskript
-├── docs/                Dokumentation
-├── src/                 Quellcode und Ressourcen
-│   ├── Main.java        Einstiegspunkt
-│   ├── MainMenu/        Hauptmen\u00fc
-│   ├── Trainer/         Logik und Oberfl\u00e4che des Trainings
-│   ├── ScoreBoard/      Highscore-Anzeige
-│   ├── Settings/        Einstellungen
-│   ├── UserManagement/  Benutzerverwaltung
-│   └── Utils/           Hilfsklassen
-```
-
-Die CSS- und FXML-Dateien liegen jeweils im gleichen Unterordner wie die zugeh\u00f6rigen Controller.
-
-## Build und Ausf\u00fchrung
-
-Vorausgesetzt werden JDK\u00a011, JavaFX und Ant. Das Projekt kann \u00fcber das beiliegende \`build.xml\` kompiliert werden:
-
-```bash
-sudo apt-get update && sudo apt-get install -y ant openjdk-11-jdk openjfx
-ant jar
-java -jar build/jar/FTF-Vokabeln.jar
-```
-
-Alternativ l\u00e4sst sich der Code in jeder IDE mit JavaFX-Unterst\u00fctzung starten. \`Main.java\` enth\u00e4lt den Einstiegspunkt.
-
-## Oberfl\u00e4chen und Controller
-
-### SceneLoader und StageAwareController
-
-Alle Szenen werden \u00fcber die Hilfsklasse \`SceneLoader\` geladen. Sie setzt die Stage, l\u00e4dt die gew\u00fcnschte FXML-Datei und bindet optional ein passendes CSS ein. Controller k\u00f6nnen von \`StageAwareController\` erben, um die Stage automatisch zu erhalten.
-
-### MainMenuController
-
-* Zeigt das Hauptmen\u00fc an
-* Kann Training, Einstellungen, Benutzerverwaltung und ScoreBoard \u00f6ffnen
-* Speichert den aktuell gew\u00e4hlten Benutzer mittels \`UserSystem\`
-
-### UserManagementController
-
-* Listet alle vorhandenen Benutzer auf
-* Neuer Benutzer kann erstellt und anschlie\u00dfend ausgew\u00e4hlt werden
-* \u00c4nderungen werden in \`user_data.csv\` gespeichert
-
-## Benutzersystem
-
-Das \`UserSystem\` verwaltet alle Benutzer samt Punktest\u00e4nden. Es nutzt ausschlie\u00dflich statische Methoden und speichert die Daten in \`src/Utils/UserScore/user_data.csv\`. Zu jeder Vokabelliste wird eine Statistik gef\u00fchrt. Wichtige Funktionen:
-
-* \`addUser\`, \`removeUser\`, \`getAllUserNames\`
-* Punktestand \u00fcber \`addPoint\` und \`getPoints\`
-* Aufzeichnen von Antworten \u00fcber \`recordAnswer\`
-* Sortieren nach Punkten (\`sortByScoreDescending\`)
-* Laden und Speichern der Daten mit \`loadFromFile\` und \`saveToFile\`
-
-## Training
-
-Der \`TrainerController\` steuert den Ablauf des Trainings:
-
-1. Beim Start wird der aktuelle Benutzer geladen und eine neue Sitzung begonnen.
-2. Abh\u00e4ngig vom in den Einstellungen gew\u00e4hlten Modus (Deutsch\u2192Englisch, Englisch\u2192Deutsch, Zuf\u00e4llig) werden Vokabeln aus dem \`TrainerModel\` gew\u00e4hlt.
-3. \`loadNextVocabSet\` baut dynamisch Eingabefelder auf und merkt sich die korrekten L\u00f6sungen.
-4. \`checkAnswers\` vergleicht die Eingaben mit der L\u00f6sung, f\u00e4rbt richtige und falsche Buchstaben ein und aktualisiert den Punktestand \u00fcber \`UserSystem\`.
-5. Nach einer kurzen Pause wird das n\u00e4chste Set geladen oder das ScoreBoard ge\u00f6ffnet.
-
-Soundeffekte werden \u00fcber \`SoundModel\` abgespielt.
-
-## ScoreBoard
-
-\`ScoreBoardController\` zeigt alle Benutzer sortiert nach Punkten an und informiert \u00fcber den Fortschritt der aktuellen Sitzung. Die Daten werden direkt aus dem \`UserSystem\` geladen.
-
-## Einstellungen
-
-Im \`SettingsController\` w\u00e4hlt der Nutzer den gew\u00fcnschten Vokabelmodus aus. Die Auswahl wird \u00fcber \`java.util.prefs.Preferences\` gespeichert und beim n\u00e4chsten Start wieder geladen.
-`;
-    const html = marked.parse(markdown);
-    document.getElementById('content').innerHTML = html;
-    buildTree();
+    fetch('Dokumentation.md')
+        .then(resp => resp.text())
+        .then(markdown => {
+            const html = marked.parse(markdown);
+            document.getElementById('content').innerHTML = html;
+            buildTree();
+        });
 
     const searchInput = document.getElementById('search');
     searchInput.addEventListener('input', () => {
@@ -143,3 +50,4 @@ function buildTree() {
         }
     });
 }
+

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,46 +1,47 @@
 body {
-    font-family: Arial, sans-serif;
+    font-family: system-ui, sans-serif;
+    line-height: 1.6;
     margin: 0;
-    background: #121212;
-    color: #ddd;
+    display: flex;
+    min-height: 100vh;
+    background: #f7f7f7;
+    color: #222;
 }
 
-a { color: #8ab4f8; }
+a { color: #0066cc; }
 
 #sidebar {
-    position: fixed;
-    top: 0;
-    left: 0;
     width: 260px;
-    height: 100%;
-    overflow: auto;
-    background: #1e1e1e;
+    overflow-y: auto;
+    background: #eaeaea;
+    border-right: 1px solid #ccc;
     padding: 1em;
-    box-shadow: 2px 0 5px rgba(0,0,0,0.3);
+    box-sizing: border-box;
 }
 
 #content {
-    margin-left: 270px;
-    padding: 1em;
+    flex: 1;
+    padding: 2em;
+    max-width: 900px;
 }
 
 pre, code {
-    background: #2b2b2b;
+    background: #e0e0e0;
     padding: 2px 4px;
 }
 
 input[type="text"] {
     width: 100%;
-    padding: 0.3em;
+    padding: 0.4em;
     margin-bottom: 0.5em;
     box-sizing: border-box;
-    background: #333;
-    border: 1px solid #555;
-    color: #ddd;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 3px;
 }
 
 .highlight {
-    background: #444;
+    background: #ffe66d;
 }
 
 #toc ul {
@@ -60,4 +61,9 @@ input[type="text"] {
 #toc a {
     color: inherit;
     text-decoration: none;
+}
+
+#sidebar a {
+    display: block;
+    margin-top: 0.5em;
 }


### PR DESCRIPTION
## Summary
- fetch documentation markdown at runtime instead of bundling it in the JS
- modernize the documentation styles
- show a link to the method overview

## Testing
- `apt-get install -y ant` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6842c4ad0ab8832689c730bfffbacda4