### PR TITLE
Enable dynamic vocab lists from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ FTF-Vokabeln ist ein kleiner Vokabeltrainer auf Basis von JavaFX. Das Projekt en
 - Speichern der Einstellungen
 - einfache Soundeffekte
 - zentraler `UserSystem`-Verwaltungscode wird jetzt statisch genutzt
+- Vokabellisten als JSON-Dateien, leicht erweiterbar
 
 ## Build
 
@@ -24,6 +25,25 @@ sudo apt-get update && sudo apt-get install -y ant openjdk-11-jdk openjfx
 ant jar
 java -jar build/jar/FTF-Vokabeln.jar
 ```
+
+## Vokabellisten hinzufügen
+
+Alle Listen befinden sich im Ordner `src/Trainer/Vocabsets`. Beim Start wird die
+in den Einstellungen gewählte Datei geladen. Neue Listen können einfach als
+JSON-Dateien mit folgendem Aufbau hinzugefügt werden:
+
+```json
+[
+  {
+    "translations": {
+      "en": "computer",
+      "de": "Computer"
+    }
+  }
+]
+```
+
+Der Dateiname erscheint anschließend in den Einstellungen zur Auswahl.
 
 ## Dokumentation
 

--- a/docs/Dokumentation.md
+++ b/docs/Dokumentation.md
@@ -16,7 +16,7 @@
 
 ## Überblick
 
-Das Programm bietet ein Hauptmenü mit Zugriff auf Training, Einstellungen, Benutzerverwaltung und Highscore-Anzeige. Vokabeln werden aus einer fest hinterlegten Liste im `TrainerModel` geladen. Für jeden Benutzer merkt sich das Programm den Punktestand sowie detaillierte Statistiken, die in einer CSV-Datei gespeichert werden.
+Das Programm bietet ein Hauptmenü mit Zugriff auf Training, Einstellungen, Benutzerverwaltung und Highscore-Anzeige. Die Vokabellisten werden beim Start aus JSON-Dateien geladen und können dadurch leicht erweitert werden. Für jeden Benutzer merkt sich das Programm den Punktestand sowie detaillierte Statistiken, die in einer CSV-Datei gespeichert werden.
 
 ## Projektstruktur
 
@@ -81,7 +81,7 @@ Das `UserSystem` verwaltet alle Benutzer samt Punkteständen. Es nutzt ausschlie
 Der `TrainerController` steuert den Ablauf des Trainings:
 
 1. Beim Start wird der aktuelle Benutzer geladen und eine neue Sitzung begonnen.
-2. Abhängig vom in den Einstellungen gewählten Modus (Deutsch→Englisch, Englisch→Deutsch, Zufällig) werden Vokabeln aus dem `TrainerModel` gewählt.
+2. Abhängig vom in den Einstellungen gewählten Modus (Deutsch→Englisch, Englisch→Deutsch, Zufällig) werden Vokabeln aus der gewählten JSON-Liste im `TrainerModel` geladen.
 3. `loadNextVocabSet` baut dynamisch Eingabefelder auf und merkt sich die korrekten Lösungen.
 4. `checkAnswers` vergleicht die Eingaben mit der Lösung, färbt richtige und falsche Buchstaben ein und aktualisiert den Punktestand über `UserSystem`.
 5. Nach einer kurzen Pause wird das nächste Set geladen oder das ScoreBoard geöffnet.
@@ -94,6 +94,6 @@ Soundeffekte werden über `SoundModel` abgespielt.
 
 ## Einstellungen
 
-Im `SettingsController` wählt der Nutzer den gewünschten Vokabelmodus aus. Die Auswahl wird über `java.util.prefs.Preferences` gespeichert und beim nächsten Start wieder geladen.
+Im `SettingsController` wählt der Nutzer den gewünschten Vokabelmodus sowie die zu verwendende Vokabelliste aus. Beide Werte werden über `java.util.prefs.Preferences` gespeichert und beim nächsten Start wieder geladen. Neue JSON-Dateien im Ordner `src/Trainer/Vocabsets` erscheinen automatisch in der Auswahlliste.
 
 

--- a/docs/Methodenliste.md
+++ b/docs/Methodenliste.md
@@ -14,9 +14,12 @@ Dieser Anhang listet exemplarisch einige wichtige Methoden des Projekts auf.
 - `initialize(URL, ResourceBundle)` – initialisiert die Auswahl des Vokabelmodus.
 
 ## TrainerController
-- `initialize()` – lädt erste Vokabeln und setzt Benutzer.
+- `initialize()` – lädt die gewählte Vokabelliste und setzt Benutzer.
 - `loadNextVocabSet()` – erstellt neue Eingabefelder.
 - `checkAnswers()` – wertet Antworten aus und zeigt das Ergebnis.
+
+## TrainerModel
+- `loadFromJson(String)` – liest Vokabeln aus einer JSON-Datei ein.
 
 ## UserManagementController
 - `createUser()` – legt einen neuen Benutzer an.

--- a/src/Settings/Settings.fxml
+++ b/src/Settings/Settings.fxml
@@ -7,16 +7,22 @@
 
 <AnchorPane prefHeight="400.0" prefWidth="500.0" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Settings.SettingsController">
    <VBox layoutX="16.0" layoutY="77.0" prefHeight="276.0" prefWidth="165.0" AnchorPane.bottomAnchor="47.0" AnchorPane.leftAnchor="16.0" AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="77.0">
-      <Label text="Vokabelmodus:" />
-      <ChoiceBox fx:id="vocabModeBox" prefHeight="15.0" prefWidth="150.0">
-         <VBox.margin>
-            <Insets />
-         </VBox.margin>
-      </ChoiceBox>
-      <Label fx:id="vDark" text="Erscheinungsbild:">
-         <VBox.margin>
-            <Insets />
-         </VBox.margin>
+       <Label text="Vokabelmodus:" />
+       <ChoiceBox fx:id="vocabModeBox" prefHeight="15.0" prefWidth="150.0">
+          <VBox.margin>
+             <Insets />
+          </VBox.margin>
+       </ChoiceBox>
+       <Label text="Vokabelliste:" />
+       <ChoiceBox fx:id="vocabListBox" prefHeight="15.0" prefWidth="150.0">
+          <VBox.margin>
+             <Insets />
+          </VBox.margin>
+       </ChoiceBox>
+       <Label fx:id="vDark" text="Erscheinungsbild:">
+          <VBox.margin>
+             <Insets />
+          </VBox.margin>
          <padding>
             <Insets top="20.0" />
          </padding></Label>

--- a/src/Settings/SettingsController.java
+++ b/src/Settings/SettingsController.java
@@ -7,6 +7,7 @@ import javafx.fxml.Initializable;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
+import java.io.File;
 import Utils.SceneLoader.SceneLoader;
 import Utils.StageAwareController;
 import javafx.scene.control.Label;
@@ -48,6 +49,8 @@ public class SettingsController extends StageAwareController implements Initiali
 
     @FXML
     private ChoiceBox<String> vocabModeBox;
+    @FXML
+    private ChoiceBox<String> vocabListBox;
 
     /**
      * Initialisiert die ComboBox für den Vokabelmodus und lädt gespeicherte Werte.
@@ -60,11 +63,26 @@ public class SettingsController extends StageAwareController implements Initiali
                 "Zufällig"
         );
 
+        File vocabDir = new File("src/Trainer/Vocabsets");
+        File[] files = vocabDir.listFiles((dir, name) -> name.toLowerCase().endsWith(".json"));
+        if (files != null) {
+            for (File f : files) {
+                vocabListBox.getItems().add(f.getName());
+            }
+        }
+
         String savedMode = prefs.get("vocabMode", "Deutsch zu Englisch");
         vocabModeBox.setValue(savedMode);
 
+        String savedFile = prefs.get("vocabFile", "defaultvocab.json");
+        if (vocabListBox.getItems().contains(savedFile)) {
+            vocabListBox.setValue(savedFile);
+        }
+
         vocabModeBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) ->
                 prefs.put("vocabMode", newVal));
+        vocabListBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) ->
+                prefs.put("vocabFile", newVal));
     }
 
     /**

--- a/src/Trainer/TrainerController.java
+++ b/src/Trainer/TrainerController.java
@@ -32,7 +32,8 @@ public class TrainerController extends StageAwareController {
     @FXML
     private Button nextButton;
 
-    private final TrainerModel model = new TrainerModel();
+    private TrainerModel model;
+    private String listId = "defaultvocab.json";
     private final SoundModel soundModel = new SoundModel();
     private final List<VocabEntry> vocabEntries = new ArrayList<>();
     private String currentUser = "user";
@@ -54,10 +55,12 @@ public class TrainerController extends StageAwareController {
         UserSystem.loadFromFile();
         currentUser = UserSystem.getCurrentUser();
         UserSystem.addUser(currentUser);
-        UserSystem.startNewSession(currentUser, null);
 
-        mode = java.util.prefs.Preferences.userNodeForPackage(SettingsController.class)
-                .get("vocabMode", "Deutsch zu Englisch");
+        var prefs = java.util.prefs.Preferences.userNodeForPackage(SettingsController.class);
+        mode = prefs.get("vocabMode", "Deutsch zu Englisch");
+        listId = prefs.get("vocabFile", "defaultvocab.json");
+        model = new TrainerModel("src/Trainer/Vocabsets/" + listId);
+        UserSystem.startNewSession(currentUser, listId);
 
         loadNextVocabSet();
 
@@ -170,7 +173,7 @@ public class TrainerController extends StageAwareController {
             if (isCorrect) {
                 UserSystem.addPoint(currentUser);
             }
-            UserSystem.recordAnswer(currentUser, isCorrect, null);
+            UserSystem.recordAnswer(currentUser, isCorrect, listId);
         }
 
         // Spiele nur EINEN Sound ab, basierend auf dem Gesamtergebnis

--- a/src/Trainer/TrainerModel.java
+++ b/src/Trainer/TrainerModel.java
@@ -1,79 +1,69 @@
 package Trainer;
 
-import java.io.FileReader;
-import java.util.Arrays;
-import java.util.List;
-//program for reading a JSON file
-
 import org.json.JSONArray;
-
 import org.json.JSONObject;
+import org.json.JSONTokener;
 
-
-
-
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Das Model hält eine feste Liste von Vokabeln.
- * Diese kann über Getter abgefragt werden.
+ * Verwaltet die Vokabellisten des Trainers. Beim Erzeugen werden die
+ * Einträge aus einer JSON-Datei geladen, standardmäßig aus
+ * {@code src/Trainer/Vocabsets/defaultvocab.json}.
  */
-
 public class TrainerModel {
-    private final List<String> vocabEnglish = Arrays.asList(
-            "apple", "banana", "house", "car", "computer",
-            "book", "pen", "school", "teacher", "student",
-            "chair", "table", "window", "door", "phone",
-            "dog", "cat", "mouse", "bird", "fish",
-            "water", "milk", "bread", "cheese", "butter",
-            "sun", "moon", "star", "sky", "cloud"
-    );
+    private final List<String> vocabEnglish = new ArrayList<>();
+    private final List<String> vocabGerman = new ArrayList<>();
 
-    private final List<String> vocabGerman = Arrays.asList(
-            "Apfel", "Banane", "Haus", "Auto", "Computer",
-            "Buch", "Stift", "Schule", "Lehrer", "Schüler",
-            "Stuhl", "Tisch", "Fenster", "Tür", "Handy",
-            "Hund", "Katze", "Maus", "Vogel", "Fisch",
-            "Wasser", "Milch", "Brot", "Käse", "Butter",
-            "Sonne", "Mond", "Stern", "Himmel", "Wolke"
-    );
-
-        public int getSize() {
-            return vocabEnglish.size();
-        }
-
-        public String get(int index) {
-            return vocabEnglish.get(index);
-        }
-
-        public String getTranslation(int index) {
-            return vocabGerman.get(index);
-        }
-}
-
-public class JSON
-
-{
-
-    public static void main(Strings args[])
-
-    {
-
-        // file name is File.json
-
-        Object o = new JSONParser().parse(new FileReader(File.json));
-
-        JSONObject j = (JSONObject) o;
-
-        String Name = (String) j.get(“Name”);
-
-        String College = (String ) j.get(“College”);
-
-
-
-        System.out.println(“Name :” + Name);
-
-        System.out.println(“College :” +College);
-
+    public TrainerModel() {
+        this("src/Trainer/Vocabsets/defaultvocab.json");
     }
 
+    public TrainerModel(String path) {
+        loadFromJson(path);
+    }
+
+    /**
+     * Lädt die Vokabeln aus der angegebenen JSON-Datei. Erwartet ein Array aus
+     * Objekten mit dem Aufbau:
+     * {@code {"translations": {"en": "...", "de": "..."}}}
+     * Fehlschläge führen lediglich zu einer leeren Liste und werden auf der
+     * Konsole gemeldet.
+     */
+    public void loadFromJson(String path) {
+        vocabEnglish.clear();
+        vocabGerman.clear();
+        Path p = Path.of(path);
+        try (InputStream in = Files.newInputStream(p)) {
+            JSONArray arr = new JSONArray(new JSONTokener(in));
+            for (int i = 0; i < arr.length(); i++) {
+                JSONObject obj = arr.getJSONObject(i);
+                if (!obj.has("translations")) continue;
+                JSONObject trans = obj.getJSONObject("translations");
+                vocabEnglish.add(trans.optString("en"));
+                vocabGerman.add(trans.optString("de"));
+            }
+        } catch (IOException e) {
+            System.err.println("Konnte Vokabeldatei nicht lesen: " + e.getMessage());
+        } catch (Exception e) {
+            System.err.println("Ungültiges JSON in " + path + ": " + e.getMessage());
+        }
+    }
+
+    public int getSize() {
+        return vocabEnglish.size();
+    }
+
+    public String get(int index) {
+        return vocabEnglish.get(index);
+    }
+
+    public String getTranslation(int index) {
+        return vocabGerman.get(index);
+    }
 }


### PR DESCRIPTION
## Summary
- read vocabulary from JSON files in `TrainerModel`
- pick vocab file in `SettingsController` and FXML
- initialise `TrainerModel` in `TrainerController` with selected file
- document JSON vocab lists in README and docs
- list `loadFromJson` in Methodenliste

## Testing
- `javac -d out $(find src -name '*.java')` *(fails: package javafx.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548f13ba1c8326992f781ae0886c41