### PR TITLE
Fix NPE loading vocab data

### DIFF
--- a/src/Trainer/TrainerController.java
+++ b/src/Trainer/TrainerController.java
@@ -66,7 +66,8 @@ public class TrainerController extends StageAwareController {
         var prefs = java.util.prefs.Preferences.userNodeForPackage(SettingsController.class);
         mode = prefs.get("vocabMode", "Deutsch zu Englisch");
         listId = prefs.get("vocabFile", "defaultvocab.json");
-        //model = new TrainerModel("src/Trainer/Vocabsets/" + listId);
+        model = new TrainerModel();
+        model.loadJsonfile("src/Trainer/Vocabsets/" + listId);
         UserSystem.startNewSession(currentUser, listId);
 
         loadNextVocabSet();


### PR DESCRIPTION
## Summary
- initialize `TrainerModel` and load selected vocab list

## Testing
- `javac $(find src -name '*.java') -d build` *(fails: package javafx.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549de089b0832698d140b788cffb39