### PR TITLE
Fix trainer vocabulary loading

### DIFF
--- a/src/Trainer/TrainerController.java
+++ b/src/Trainer/TrainerController.java
@@ -67,6 +67,8 @@ public class TrainerController extends StageAwareController {
         mode = prefs.get("vocabMode", "Deutsch zu Englisch");
         listId = prefs.get("vocabFile", "defaultvocab.json");
         model = new TrainerModel();
+        String vocabPath = "src/Trainer/Vocabsets/" + listId;
+        model.LoadJSONtoDataObj(vocabPath);
         UserSystem.startNewSession(currentUser, listId);
 
         loadNextVocabSet();


### PR DESCRIPTION
## Summary
- load selected vocabulary list when initializing Trainer

## Testing
- `javac @sources.txt` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6859503692ac8326b54a7a387b8deae6