### PR TITLE
Enhance trainer rounds and scoring

### DIFF
--- a/src/Utils/UserScore/UserSystem.java
+++ b/src/Utils/UserScore/UserSystem.java
@@ -179,8 +179,16 @@ public final class UserSystem {
 
     // Punktestandverwaltung
     public static void addPoint(String name) {
+        addPoints(name, 1);
+    }
+
+    /**
+     * Adds the given amount of points to the user. Negative values are ignored.
+     */
+    public static void addPoints(String name, int amount) {
+        if (amount <= 0) return;
         User u = getUserByName(name);
-        if (u != null) u.points++;
+        if (u != null) u.points += amount;
     }
 
     public static void setPoints(String name, int points) {


### PR DESCRIPTION
## Summary
- add difficulty-aware scoring and helper methods
- show translation languages in random mode
- play sounds based on percentage of correct answers
- continue training after each round without stopping

## Testing
- `apt-get update`
- `apt-get install -y openjfx`
- `javac @sources.txt` *(fails: package javafx.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595169956083268fb5fb70e014990a