### PR TITLE
Enhance trainer rounds and completion control

### DIFF
--- a/src/Trainer/Trainer.fxml
+++ b/src/Trainer/Trainer.fxml
@@ -21,6 +21,7 @@
         <HBox spacing="10.0">
             <Button fx:id="backButton" text="Zurück zum Menü" />
             <Button fx:id="nextButton" text="Weiter" />
+            <Button fx:id="finishButton" text="Vorzeitig beenden" />
         </HBox>
     </VBox>
 

--- a/src/Utils/UserScore/UserSystem.java
+++ b/src/Utils/UserScore/UserSystem.java
@@ -179,8 +179,16 @@ public final class UserSystem {
 
     // Punktestandverwaltung
     public static void addPoint(String name) {
+        addPoints(name, 1);
+    }
+
+    /**
+     * Adds the given amount of points to the user. Negative values are ignored.
+     */
+    public static void addPoints(String name, int amount) {
+        if (amount <= 0) return;
         User u = getUserByName(name);
-        if (u != null) u.points++;
+        if (u != null) u.points += amount;
     }
 
     public static void setPoints(String name, int points) {


### PR DESCRIPTION
## Summary
- ensure all vocab questions are used before finishing
- allow early termination through a new button
- keep difficulty-based scoring and language labels

## Testing
- `apt-get update`
- `apt-get install -y openjfx`
- `javac @sources.txt` *(fails: package javafx.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595169956083268fb5fb70e014990a