### PR TITLE
Fix missing Label import in Trainer.fxml

### DIFF
--- a/src/Trainer/Trainer.fxml
+++ b/src/Trainer/Trainer.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>


### PR DESCRIPTION
## Summary
- add `Label` import to `Trainer.fxml`

## Testing
- `javac --module-path /usr/share/openjfx/lib --add-modules javafx.controls,javafx.fxml,javafx.media -cp json.jar @sources.txt -d build/classes` (compilation succeeds)


------
https://chatgpt.com/codex/tasks/task_e_68595a379ef08326a32b49cec67a98f3