### PR TITLE
Filter vocab modes by available languages

### DIFF
--- a/docs/Dokumentation.md
+++ b/docs/Dokumentation.md
@@ -81,7 +81,7 @@ Das `UserSystem` verwaltet alle Benutzer samt Punkteständen. Es nutzt ausschlie
 Der `TrainerController` steuert den Ablauf des Trainings:
 
 1. Beim Start wird der aktuelle Benutzer geladen und eine neue Sitzung begonnen.
-2. Abhängig vom in den Einstellungen gewählten Modus (Deutsch→Englisch, Englisch→Deutsch, Zufällig) werden Vokabeln aus der gewählten JSON-Liste im `TrainerModel` geladen.
+2. Abhängig vom in den Einstellungen gewählten Modus (z.B. Deutsch→Englisch oder Zufällig) werden Vokabeln aus der gewählten JSON-Liste im `TrainerModel` geladen.
 3. `loadNextVocabSet` baut dynamisch Eingabefelder auf und merkt sich die korrekten Lösungen.
 4. `checkAnswers` vergleicht die Eingaben mit der Lösung, färbt richtige und falsche Buchstaben ein und aktualisiert den Punktestand über `UserSystem`.
 5. Nach einer kurzen Pause wird das nächste Set geladen oder das ScoreBoard geöffnet.
@@ -94,6 +94,6 @@ Soundeffekte werden über `SoundModel` abgespielt.
 
 ## Einstellungen
 
-Im `SettingsController` wählt der Nutzer den gewünschten Vokabelmodus sowie die zu verwendende Vokabelliste aus. Beide Werte werden über `java.util.prefs.Preferences` gespeichert und beim nächsten Start wieder geladen. Neue JSON-Dateien im Ordner `src/Trainer/Vocabsets` erscheinen automatisch in der Auswahlliste.
+Im `SettingsController` wählt der Nutzer den gewünschten Vokabelmodus sowie die zu verwendende Vokabelliste aus. Beide Werte werden über `java.util.prefs.Preferences` gespeichert und beim nächsten Start wieder geladen. Die verfügbaren Modi richten sich nach den Sprachen der gewählten Liste. Neue JSON-Dateien im Ordner `src/Trainer/Vocabsets` erscheinen automatisch in der Auswahlliste.
 
 

--- a/src/Settings/SettingsController.java
+++ b/src/Settings/SettingsController.java
@@ -52,22 +52,57 @@ public class SettingsController extends StageAwareController implements Initiali
     @FXML
     private ChoiceBox<String> vocabListBox;
 
+    private static final java.util.Map<String, String> LANG_NAMES = java.util.Map.of(
+            "de", "Deutsch",
+            "en", "Englisch",
+            "fr", "Französisch",
+            "es", "Spanisch"
+    );
+
+    private java.util.List<String> generateModes(java.util.Set<String> langs) {
+        java.util.List<String> codes = new java.util.ArrayList<>(LANG_NAMES.keySet());
+        codes.removeIf(code -> !langs.contains(code));
+        for (String code : langs) {
+            if (!codes.contains(code)) codes.add(code);
+        }
+
+        java.util.List<String> modes = new java.util.ArrayList<>();
+        for (String q : codes) {
+            for (String a : codes) {
+                if (!q.equals(a)) {
+                    String qName = LANG_NAMES.getOrDefault(q, q);
+                    String aName = LANG_NAMES.getOrDefault(a, a);
+                    modes.add(qName + " zu " + aName);
+                }
+            }
+        }
+        if (codes.size() >= 2) {
+            modes.add("Zufällig");
+        }
+        return modes;
+    }
+
+    private void updateVocabModes() {
+        String file = vocabListBox.getValue();
+        if (file == null) return;
+        Trainer.TrainerModel model = new Trainer.TrainerModel();
+        model.LoadJSONtoDataObj("src/Trainer/Vocabsets/" + file);
+        java.util.Set<String> langs = model.getAvailableLanguages();
+        java.util.List<String> options = generateModes(langs);
+        String current = vocabModeBox.getValue();
+        vocabModeBox.getItems().setAll(options);
+        if (current != null && options.contains(current)) {
+            vocabModeBox.setValue(current);
+        } else if (!options.isEmpty()) {
+            vocabModeBox.setValue(options.get(0));
+        }
+    }
+
     /**
      * Initialisiert die ComboBox für den Vokabelmodus und lädt gespeicherte Werte.
      */
     @Override
     public void initialize(URL location, ResourceBundle resources) {
-        vocabModeBox.getItems().addAll(
-                "Deutsch zu Englisch",
-                "Englisch zu Deutsch",
-                "Deutsch zu Französisch",
-                "Französisch zu Deutsch",
-                "Deutsch zu Spanisch",
-                "Spanisch zu Deutsch",
-                "Zufällig"
-        );
-
-
         File vocabDir = new File("src/Trainer/Vocabsets");
         File[] files = vocabDir.listFiles((dir, name) -> name.toLowerCase().endsWith(".json"));
         if (files != null) {
@@ -76,18 +111,24 @@ public class SettingsController extends StageAwareController implements Initiali
             }
         }
 
-        String savedMode = prefs.get("vocabMode", "Deutsch zu Englisch");
-        vocabModeBox.setValue(savedMode);
-
         String savedFile = prefs.get("vocabFile", "defaultvocab.json");
         if (vocabListBox.getItems().contains(savedFile)) {
             vocabListBox.setValue(savedFile);
         }
 
+        updateVocabModes();
+
+        String savedMode = prefs.get("vocabMode", vocabModeBox.getValue());
+        if (vocabModeBox.getItems().contains(savedMode)) {
+            vocabModeBox.setValue(savedMode);
+        }
+
         vocabModeBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) ->
                 prefs.put("vocabMode", newVal));
-        vocabListBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) ->
-                prefs.put("vocabFile", newVal));
+        vocabListBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
+            prefs.put("vocabFile", newVal);
+            updateVocabModes();
+        });
     }
 
     /**

--- a/src/Trainer/TrainerController.java
+++ b/src/Trainer/TrainerController.java
@@ -55,6 +55,7 @@ public class TrainerController extends StageAwareController {
     private int currentIndex = 0;
     private int questionsPerRound = 5;
     private int sessionPoints = 0;
+    private List<String> availableLanguages = new ArrayList<>();
 
     private static class VocabEntry {
         String solution;
@@ -103,6 +104,7 @@ public class TrainerController extends StageAwareController {
         model = new TrainerModel();
         String vocabPath = "src/Trainer/Vocabsets/" + listId;
         model.LoadJSONtoDataObj(vocabPath);
+        availableLanguages = new ArrayList<>(model.getAvailableLanguages());
         UserSystem.startNewSession(currentUser, listId);
 
         remainingIds = new ArrayList<>(model.getAllIds());
@@ -164,10 +166,17 @@ public class TrainerController extends StageAwareController {
                     break;
                 case "Zufällig":
                 default:
-                    List<String> langs = new ArrayList<>(List.of("en", "de", "fr", "es"));
-                    Collections.shuffle(langs);
-                    questionLang = langs.get(0);
-                    answerLang = langs.get(1).equals(questionLang) ? langs.get(2) : langs.get(1);
+                    List<String> langs = new ArrayList<>(availableLanguages);
+                    if (langs.size() < 2) {
+                        questionLang = answerLang = langs.isEmpty() ? "" : langs.get(0);
+                    } else {
+                        Collections.shuffle(langs);
+                        questionLang = langs.get(0);
+                        answerLang = langs.get(1);
+                        if (answerLang.equals(questionLang) && langs.size() > 2) {
+                            answerLang = langs.get(2);
+                        }
+                    }
                     break;
             }
 

--- a/src/Trainer/TrainerModel.java
+++ b/src/Trainer/TrainerModel.java
@@ -21,6 +21,8 @@ public class TrainerModel {
     private final List<String> spanishList = new ArrayList<>();
     private final List<String> frenchList = new ArrayList<>();
 
+    private final Set<String> availableLanguages = new HashSet<>();
+
     public TrainerModel() {}
     // Map<ID, Map<"en"/"de"/"difficulty", String>>
     private final Map<String, Map<String, String>> vocabData = new HashMap<>();
@@ -28,6 +30,7 @@ public class TrainerModel {
         vocabData.clear();
         try(InputStream in = Files.newInputStream(Path.of(fileName))){
             JSONArray array = new JSONArray(new JSONTokener(in));
+            availableLanguages.clear();
             for (int i = 0; i < array.length(); i++) {
                 JSONObject obj = array.getJSONObject(i);
                 String id = obj.getString("id");
@@ -36,6 +39,7 @@ public class TrainerModel {
                 Map<String, String> data = new HashMap<>();
                 for (String lang : translations.keySet()) {
                     data.put(lang, translations.getString(lang).trim());
+                    availableLanguages.add(lang);
                 }
                 data.put("difficulty", difficulty);
                 vocabData.put(id, data);
@@ -55,6 +59,10 @@ public class TrainerModel {
     }
     public Set<String> getAllIds() {
         return vocabData.keySet();
+    }
+
+    public Set<String> getAvailableLanguages() {
+        return new HashSet<>(availableLanguages);
     }
 
 }


### PR DESCRIPTION
## Summary
- detect available languages in `TrainerModel`
- show only valid language combinations in `SettingsController`
- random mode now uses languages from the selected list
- document dynamic mode selection

## Testing
- `javac @sources.txt` *(fails: package javafx.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595c4859548326af5f57327304c438