### PR TITLE
Fix settings mode order and default

### DIFF
--- a/src/Settings/Settings.fxml
+++ b/src/Settings/Settings.fxml
@@ -7,14 +7,14 @@
 
 <AnchorPane prefHeight="400.0" prefWidth="500.0" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Settings.SettingsController">
    <VBox layoutX="16.0" layoutY="77.0" prefHeight="276.0" prefWidth="165.0" AnchorPane.bottomAnchor="47.0" AnchorPane.leftAnchor="16.0" AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="77.0">
-       <Label text="Vokabelmodus:" />
-       <ChoiceBox fx:id="vocabModeBox" prefHeight="15.0" prefWidth="150.0">
+       <Label text="Vokabelliste:" />
+       <ChoiceBox fx:id="vocabListBox" prefHeight="15.0" prefWidth="150.0">
           <VBox.margin>
              <Insets />
           </VBox.margin>
        </ChoiceBox>
-       <Label text="Vokabelliste:" />
-       <ChoiceBox fx:id="vocabListBox" prefHeight="15.0" prefWidth="150.0">
+       <Label text="Vokabelmodus:" />
+       <ChoiceBox fx:id="vocabModeBox" prefHeight="15.0" prefWidth="150.0">
           <VBox.margin>
              <Insets />
           </VBox.margin>

--- a/src/Settings/SettingsController.java
+++ b/src/Settings/SettingsController.java
@@ -96,7 +96,11 @@ public class SettingsController extends StageAwareController implements Initiali
         if (current != null && options.contains(current)) {
             vocabModeBox.setValue(current);
         } else if (!options.isEmpty()) {
-            vocabModeBox.setValue(options.get(0));
+            if (options.contains("Zufällig")) {
+                vocabModeBox.setValue("Zufällig");
+            } else {
+                vocabModeBox.setValue(options.get(0));
+            }
         }
     }
 
@@ -120,7 +124,7 @@ public class SettingsController extends StageAwareController implements Initiali
 
         updateVocabModes();
 
-        String savedMode = prefs.get("vocabMode", vocabModeBox.getValue());
+        String savedMode = prefs.get("vocabMode", "Zufällig");
         if (vocabModeBox.getItems().contains(savedMode)) {
             vocabModeBox.setValue(savedMode);
         }
@@ -128,8 +132,11 @@ public class SettingsController extends StageAwareController implements Initiali
         vocabModeBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) ->
                 prefs.put("vocabMode", newVal));
 
-        vocabListBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) ->
-                prefs.put("vocabFile", newVal));
+        vocabListBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
+            prefs.put("vocabFile", newVal);
+            updateVocabModes();
+            prefs.put("vocabMode", vocabModeBox.getValue());
+        });
 
         darkCss = getClass().getResource("/dark.css").toExternalForm();
         boolean dark = prefs.getBoolean("darkMode", false);


### PR DESCRIPTION
## Summary
- reorder Settings UI to choose vocab list first
- set default vocab mode to Random
- update mode options when changing the vocab list

## Testing
- `apt-get update && apt-get install -y ant`
- `ant jar` *(fails: build.xml missing)*
- `javac @sources.txt` *(fails: missing JavaFX packages)*

------
https://chatgpt.com/codex/tasks/task_e_68595ed791e0832680a5d4214b101a63