### PR TITLE
Use responsive layouts in all scenes

### DIFF
--- a/src/MainMenu/mainMenu.fxml
+++ b/src/MainMenu/mainMenu.fxml
@@ -5,28 +5,28 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.*?>
 
-<AnchorPane prefHeight="450.0" prefWidth="501.0" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="MainMenu.MainMenuController">
-<HBox prefHeight="25.0" prefWidth="35.0" AnchorPane.topAnchor="0.0" AnchorPane.leftAnchor="0.0">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="MainMenu.MainMenuController">
+<HBox AnchorPane.topAnchor="0.0" AnchorPane.leftAnchor="0.0">
 
-            <Button fx:id="burgerMenu" alignment="CENTER" mnemonicParsing="false" onAction="#toggleSideMenu" prefHeight="29.3" prefWidth="31.3" text="≡" />
+            <Button fx:id="burgerMenu" alignment="CENTER" mnemonicParsing="false" onAction="#toggleSideMenu" text="≡" />
          <!--fx:id="burgerButton"-->
       </HBox>
-<VBox alignment="CENTER" layoutX="9.0" layoutY="33.0" prefHeight="394.0" prefWidth="492.0" spacing="20.0" AnchorPane.topAnchor="33.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0">
+<VBox alignment="CENTER" layoutX="9.0" layoutY="33.0" spacing="20.0" AnchorPane.topAnchor="33.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.bottomAnchor="0.0">
 
             <Label fx:id="mainLabel" alignment="TOP_CENTER" text="Vokabeltrainer">
                <font>
                   <Font name="System Bold" size="22.0" />
                </font>
             </Label>
-      <VBox alignment="TOP_CENTER" prefHeight="22.0" prefWidth="492.0">
+      <VBox alignment="TOP_CENTER">
          <children>
-                <HBox alignment="CENTER" prefHeight="38.0" prefWidth="492.0">
+                <HBox alignment="CENTER">
                     <TextField fx:id="userField" alignment="CENTER" maxWidth="100.0" promptText="Benutzername">
                         <HBox.margin>
                             <Insets left="30.0" />
                         </HBox.margin>
                     </TextField>
-                    <VBox alignment="CENTER_LEFT" prefHeight="51.0" prefWidth="54.0">
+                    <VBox alignment="CENTER_LEFT">
                         <Button fx:id="searchButton" mnemonicParsing="false" onAction="#handleSearchUser" text="🔍" />
                         <Button fx:id="addButton" mnemonicParsing="false" onAction="#handleCreateUser" text="+" />
                     </VBox>
@@ -41,9 +41,9 @@
             <Button fx:id="exitButton" mnemonicParsing="false" onAction="#handleExit" text="Beenden" />
          <!--fx:id="exitButton"-->
       </VBox>
-      <VBox fx:id="sideMenu" layoutY="37.0" prefHeight="363.0" prefWidth="159.0" visible="false" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="350.0" AnchorPane.topAnchor="25.0">
+      <VBox fx:id="sideMenu" layoutY="37.0" visible="false" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="350.0" AnchorPane.topAnchor="25.0">
    <!--style="-fx-background-color: rgb(77,77,77);"-->
-            <Button fx:id="buttonSettings" mnemonicParsing="false" onAction="#openSettings" prefHeight="25.0" prefWidth="163.0" text="Einstellungen">
+            <Button fx:id="buttonSettings" mnemonicParsing="false" onAction="#openSettings" text="Einstellungen">
                <VBox.margin>
                   <Insets />
                </VBox.margin></Button>

--- a/src/ScoreBoard/ScoreBoard.fxml
+++ b/src/ScoreBoard/ScoreBoard.fxml
@@ -3,12 +3,12 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
-<AnchorPane prefHeight="400.0" prefWidth="509.0" xmlns="http://javafx.com/javafx/17.0.12"
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" xmlns="http://javafx.com/javafx/17.0.12"
             xmlns:fx="http://javafx.com/fxml/1" fx:controller="ScoreBoard.ScoreBoardController">
     <VBox spacing="10" AnchorPane.topAnchor="10" AnchorPane.leftAnchor="10" AnchorPane.rightAnchor="10"
           AnchorPane.bottomAnchor="10">
         <Label fx:id="userLabel" text="Statistik"/>
-        <TableView fx:id="allTable" prefHeight="150.0">
+        <TableView fx:id="allTable">
             <columns>
                 <TableColumn fx:id="listColumn" text="Liste" prefWidth="200.0"/>
                 <TableColumn fx:id="correctColumn" text="Richtig"/>
@@ -18,7 +18,7 @@
         <HBox spacing="5">
             <ChoiceBox fx:id="listChoiceBox" />
         </HBox>
-        <TableView fx:id="singleTable" prefHeight="100.0">
+        <TableView fx:id="singleTable">
             <columns>
                 <TableColumn fx:id="sListColumn" text="Liste" prefWidth="200.0"/>
                 <TableColumn fx:id="sCorrectColumn" text="Richtig"/>

--- a/src/Settings/Settings.fxml
+++ b/src/Settings/Settings.fxml
@@ -5,16 +5,16 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.*?>
 
-<AnchorPane prefHeight="400.0" prefWidth="500.0" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Settings.SettingsController">
-   <VBox layoutX="16.0" layoutY="77.0" prefHeight="276.0" prefWidth="165.0" AnchorPane.bottomAnchor="47.0" AnchorPane.leftAnchor="16.0" AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="77.0">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Settings.SettingsController">
+   <VBox layoutX="16.0" layoutY="77.0" AnchorPane.bottomAnchor="47.0" AnchorPane.leftAnchor="16.0" AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="77.0">
        <Label text="Vokabelliste:" />
-       <ChoiceBox fx:id="vocabListBox" prefHeight="15.0" prefWidth="150.0">
+       <ChoiceBox fx:id="vocabListBox">
           <VBox.margin>
              <Insets />
           </VBox.margin>
        </ChoiceBox>
        <Label text="Vokabelmodus:" />
-       <ChoiceBox fx:id="vocabModeBox" prefHeight="15.0" prefWidth="150.0">
+       <ChoiceBox fx:id="vocabModeBox">
           <VBox.margin>
              <Insets />
           </VBox.margin>
@@ -26,9 +26,9 @@
          <padding>
             <Insets top="20.0" />
          </padding></Label>
-      <CheckBox fx:id="darkModeToggle" prefHeight="19.0" prefWidth="103.0" text="Dark Mode" />
+      <CheckBox fx:id="darkModeToggle" text="Dark Mode" />
    </VBox>
-   <Label fx:id="mainLable" layoutX="197.0" layoutY="38.0" prefHeight="17.0" prefWidth="129.0" text="Einstellungen">
+   <Label fx:id="mainLable" layoutX="197.0" layoutY="38.0" text="Einstellungen">
       <font>
          <Font size="18.0" />
       </font>

--- a/src/UserManagement/UserManagement.fxml
+++ b/src/UserManagement/UserManagement.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
-<AnchorPane prefHeight="400.0" prefWidth="509.0" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1"
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="UserManagement.UserManagementController">
     <VBox spacing="10" AnchorPane.topAnchor="10" AnchorPane.leftAnchor="10" AnchorPane.rightAnchor="10"
           AnchorPane.bottomAnchor="10">
@@ -16,7 +16,7 @@
             <TextField fx:id="searchField" promptText="Suchen"/>
             <Button text="Auswählen" onAction="#selectUser"/>
         </HBox>
-        <ListView fx:id="userList" prefHeight="200.0"/>
+        <ListView fx:id="userList" />
         <Button fx:id="backButton" text="Zurück" onAction="#backToMenu"/>
     </VBox>
 </AnchorPane>


### PR DESCRIPTION
## Summary
- remove fixed pref sizes from FXML layouts so nodes expand with the maximized stage
- keep stage maximized when loading scenes

## Testing
- `javac -d out/classes @sources.txt` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685961c5d5708326a4cb456424f62b4f