### PR TITLE
Fix icon loading path

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -2,6 +2,7 @@ import Utils.SceneLoader.SceneLoader;
 import javafx.application.Application;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
+import java.util.Objects;
 
 /*
 7PG_T2 Vokabeltrainer
@@ -32,7 +33,9 @@ public class Main extends Application {
         //Fenster zentrieren
         primaryStage.centerOnScreen();
 
-        Image icon = new Image("utils/media/logo.png", 128, 128, true, true);
+        Image icon = new Image(Objects.requireNonNull(
+                getClass().getResourceAsStream("/Utils/media/Logo.png")),
+                128, 128, true, true);
         if (icon.isError()) {
             System.out.println("Logo konnte nicht geladen werden: " + icon.getException());
         } else {


### PR DESCRIPTION
## Summary
- fix path for main application icon

## Testing
- `javac --module-path /usr/share/openjfx/lib --add-modules javafx.controls,javafx.fxml,javafx.media -cp lib/json-20250517.jar -d build $(find src -name '*.java')`
- `java --module-path /usr/share/openjfx/lib --add-modules javafx.controls,javafx.fxml,javafx.media -cp build:lib/json-20250517.jar Main` *(fails: Unable to open DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6861a8e7eaa883269261d9c3092135f6