### PR TITLE
Fix NPE when training list empty

### DIFF
--- a/src/Trainer/TrainerController.java
+++ b/src/Trainer/TrainerController.java
@@ -231,6 +231,10 @@ public class TrainerController extends StageAwareController {
     }
 
     private void finishTraining() {
-        SceneLoader.load(stage, "/ScoreBoard/ScoreBoard.fxml");
+        if (stage != null) {
+            SceneLoader.load(stage, "/ScoreBoard/ScoreBoard.fxml");
+        } else {
+            SceneLoader.load("/ScoreBoard/ScoreBoard.fxml");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid using a null stage when opening the scoreboard

## Testing
- `javac @sources.txt` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6861a9c91df483269748695647f5f95e