### PR TITLE
Persist preferences in user.json

### DIFF
--- a/docs/Dokumentation.md
+++ b/docs/Dokumentation.md
@@ -94,6 +94,6 @@ Soundeffekte werden über `SoundModel` abgespielt.
 
 ## Einstellungen
 
-Im `SettingsController` wählt der Nutzer den gewünschten Vokabelmodus sowie die zu verwendende Vokabelliste aus. Beide Werte werden über `java.util.prefs.Preferences` gespeichert und beim nächsten Start wieder geladen. Die verfügbaren Modi richten sich nach den Sprachen der gewählten Liste. Neue JSON-Dateien im Ordner `src/Trainer/Vocabsets` erscheinen automatisch in der Auswahlliste.
+Im `SettingsController` wählt der Nutzer den gewünschten Vokabelmodus sowie die zu verwendende Vokabelliste aus. Diese Einstellungen werden jetzt gemeinsam mit dem aktuellen Dark‑Mode‑Status in `user.json` gespeichert und beim nächsten Start wieder geladen. Die verfügbaren Modi richten sich nach den Sprachen der gewählten Liste. Neue JSON-Dateien im Ordner `src/Trainer/Vocabsets` erscheinen automatisch in der Auswahlliste.
 
 

--- a/src/Settings/SettingsController.java
+++ b/src/Settings/SettingsController.java
@@ -15,15 +15,11 @@ import javafx.scene.control.Label;
 
 import java.net.URL;
 import java.util.ResourceBundle;
-import java.util.prefs.Preferences;
 
 /**
  * Controller für die Einstellungen.
  */
 public class SettingsController extends StageAwareController implements Initializable {
-
-    // Einstellungen werden im Preferences-Objekt gespeichert
-    private final Preferences prefs = Preferences.userNodeForPackage(SettingsController.class);
 
     public Label mainLable;
     public Button Button;
@@ -109,45 +105,50 @@ public class SettingsController extends StageAwareController implements Initiali
      */
     @Override
     public void initialize(URL location, ResourceBundle resources) {
+        UserSys.loadFromJson();
+
         for (String name : listVocabFiles()) {
             vocabListBox.getItems().add(name);
         }
 
-        String savedFile = prefs.get("vocabFile", "defaultvocab.json");
+        String savedFile = UserSys.getPreference("vocabFile", "defaultvocab.json");
         if (vocabListBox.getItems().contains(savedFile)) {
             vocabListBox.setValue(savedFile);
         }
 
         updateVocabModes();
 
-        String savedMode = prefs.get("vocabMode", "Zufällig");
+        String savedMode = UserSys.getPreference("vocabMode", "Zufällig");
         if (vocabModeBox.getItems().contains(savedMode)) {
             vocabModeBox.setValue(savedMode);
         }
 
         vocabModeBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
             if (newVal != null) {
-                prefs.put("vocabMode", newVal);
+                UserSys.setPreference("vocabMode", newVal);
+                UserSys.saveToJson();
             }
         });
 
         vocabListBox.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
             if (newVal != null) {
-                prefs.put("vocabFile", newVal);
+                UserSys.setPreference("vocabFile", newVal);
             }
             updateVocabModes();
             String mode = vocabModeBox.getValue();
             if (mode != null) {
-                prefs.put("vocabMode", mode);
+                UserSys.setPreference("vocabMode", mode);
             }
+            UserSys.saveToJson();
         });
 
         darkCss = getClass().getResource("/dark.css").toExternalForm();
-        boolean dark = prefs.getBoolean("darkMode", false);
+        boolean dark = UserSys.getBooleanPreference("darkMode", false);
         darkModeToggle.setSelected(dark);
         darkModeToggle.selectedProperty().addListener((obs, o, n) -> {
-            prefs.putBoolean("darkMode", n);
+            UserSys.setBooleanPreference("darkMode", n);
             applyDarkMode();
+            UserSys.saveToJson();
         });
 
         javafx.application.Platform.runLater(this::applyDarkMode);

--- a/src/Trainer/TrainerController.java
+++ b/src/Trainer/TrainerController.java
@@ -62,9 +62,9 @@ public class TrainerController extends StageAwareController {
             pointsLabel.setText("Punkte: 0");
         }
 
-        var prefs = java.util.prefs.Preferences.userNodeForPackage(SettingsController.class);
-        mode = prefs.get("vocabMode", "Deutsch zu Englisch");
-        listId = prefs.get("vocabFile", "defaultvocab.json");
+        UserSys.loadFromJson();
+        mode = UserSys.getPreference("vocabMode", "Deutsch zu Englisch");
+        listId = UserSys.getPreference("vocabFile", "defaultvocab.json");
 
         model = new TrainerModel();
         model.LoadJSONtoDataObj(listId);

--- a/src/Utils/SceneLoader/SceneLoader.java
+++ b/src/Utils/SceneLoader/SceneLoader.java
@@ -7,8 +7,7 @@ import javafx.stage.Stage;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.prefs.Preferences;
-import Settings.SettingsController;
+import Utils.UserSys.UserSys;
 
 public class SceneLoader {
 
@@ -64,8 +63,8 @@ public class SceneLoader {
                 System.out.println("⚠️ Keine CSS-Datei gefunden für " + cssPath);
             }
 
-            Preferences prefs = Preferences.userNodeForPackage(SettingsController.class);
-            if (prefs.getBoolean("darkMode", false)) {
+            UserSys.loadFromJson();
+            if (UserSys.getBooleanPreference("darkMode", false)) {
                 URL darkUrl = SceneLoader.class.getResource("/dark.css");
                 if (darkUrl != null) {
                     scene.getStylesheets().add(darkUrl.toExternalForm());

--- a/src/Utils/UserSys/UserSys.java
+++ b/src/Utils/UserSys/UserSys.java
@@ -14,6 +14,7 @@ public class UserSys {
 
     private static final List<User> users = new ArrayList<>();
     private static String currentUser = "user";
+    private static final Map<String, Object> preferences = new HashMap<>();
 
     public static void loadFromJson() {
         try (InputStream in = UserSys.class.getResourceAsStream("/Utils/UserSys/user.json")) {
@@ -21,6 +22,13 @@ public class UserSys {
 
             JSONObject root = new JSONObject(new JSONTokener(in));
             currentUser = root.optString("currentUser", "user");
+            JSONObject prefsObj = root.optJSONObject("preferences");
+            preferences.clear();
+            if (prefsObj != null) {
+                for (String key : prefsObj.keySet()) {
+                    preferences.put(key, prefsObj.get(key));
+                }
+            }
             JSONArray userArray = root.getJSONArray("users");
             users.clear();
             for (int i = 0; i < userArray.length(); i++) {
@@ -36,6 +44,8 @@ public class UserSys {
         Path path = Path.of("src", "Utils", "UserSys", "user.json"); // Dev-Pfad (zur Laufzeit ggf. anpassen)
         JSONObject root = new JSONObject();
         root.put("currentUser", currentUser);
+        JSONObject prefsObj = new JSONObject(preferences);
+        root.put("preferences", prefsObj);
         JSONArray userArray = new JSONArray();
         for (User u : users) {
             userArray.put(u.toJson());
@@ -104,6 +114,26 @@ public class UserSys {
 
     public static String getCurrentUser() {
         return currentUser;
+    }
+
+    public static String getPreference(String key, String def) {
+        Object val = preferences.get(key);
+        return val != null ? val.toString() : def;
+    }
+
+    public static boolean getBooleanPreference(String key, boolean def) {
+        Object val = preferences.get(key);
+        if (val instanceof Boolean b) return b;
+        if (val instanceof String s) return Boolean.parseBoolean(s);
+        return def;
+    }
+
+    public static void setPreference(String key, String value) {
+        preferences.put(key, value);
+    }
+
+    public static void setBooleanPreference(String key, boolean value) {
+        preferences.put(key, value);
     }
 
     public static User getUser(String name) {

--- a/src/Utils/UserSys/user.json
+++ b/src/Utils/UserSys/user.json
@@ -1,5 +1,10 @@
 {
   "currentUser": "adssd",
+  "preferences": {
+    "vocabFile": "defaultvocab.json",
+    "vocabMode": "Zufällig",
+    "darkMode": false
+  },
   "users": [
     {
       "stats": {


### PR DESCRIPTION
## Summary
- store vocabulary list, mode and dark mode in `user.json`
- load these preferences for trainer and settings
- apply dark mode using stored preference
- update docs
- add example preferences to `user.json`

## Testing
- `javac -cp lib/json-20250517.jar @<(find src -name '*.java' | tr '\n' ' ')` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6861ae90f20083268b6a8bf4827e6126