### PR TITLE
Implement chart-based scoreboard

### DIFF
--- a/src/MainMenu/MainMenuController.java
+++ b/src/MainMenu/MainMenuController.java
@@ -3,6 +3,7 @@ package MainMenu;
 import Utils.SceneLoader.SceneLoader;
 import Utils.StageAwareController;
 import Utils.UserSys.UserSys;
+import ScoreBoard.ScoreBoardController;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
@@ -50,6 +51,7 @@ public class MainMenuController extends StageAwareController {
     }
 
     public void openScoreBoard() {
+        ScoreBoard.ScoreBoardController.setLastSessionList(null);
         SceneLoader.load("/ScoreBoard/ScoreBoard.fxml");
     }
 

--- a/src/ScoreBoard/ScoreBoard.fxml
+++ b/src/ScoreBoard/ScoreBoard.fxml
@@ -1,30 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" xmlns="http://javafx.com/javafx/17.0.12"
-            xmlns:fx="http://javafx.com/fxml/1" fx:controller="ScoreBoard.ScoreBoardController">
-    <VBox spacing="10" AnchorPane.topAnchor="10" AnchorPane.leftAnchor="10" AnchorPane.rightAnchor="10"
-          AnchorPane.bottomAnchor="10">
-        <Label fx:id="userLabel" text="Statistik"/>
-        <TableView fx:id="allTable">
-            <columns>
-                <TableColumn fx:id="listColumn" text="Liste" prefWidth="200.0"/>
-                <TableColumn fx:id="correctColumn" text="Richtig"/>
-                <TableColumn fx:id="incorrectColumn" text="Falsch"/>
-            </columns>
-        </TableView>
+<?import javafx.scene.chart.*?>
+<AnchorPane xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="ScoreBoard.ScoreBoardController">
+    <VBox spacing="10" AnchorPane.topAnchor="10" AnchorPane.leftAnchor="10" AnchorPane.rightAnchor="10" AnchorPane.bottomAnchor="10">
+        <Label fx:id="userLabel" text="Statistik" />
+        <BarChart fx:id="overallChart" prefHeight="200">
+            <xAxis><CategoryAxis label="Liste"/></xAxis>
+            <yAxis><NumberAxis label="Anzahl"/></yAxis>
+        </BarChart>
         <HBox spacing="5">
             <ChoiceBox fx:id="listChoiceBox" />
+            <ChoiceBox fx:id="modeChoiceBox" />
+            <TextField fx:id="countField" prefWidth="60" />
+            <Button text="Aktualisieren" onAction="#updateComparisonChart" />
         </HBox>
-        <TableView fx:id="singleTable">
-            <columns>
-                <TableColumn fx:id="sListColumn" text="Liste" prefWidth="200.0"/>
-                <TableColumn fx:id="sCorrectColumn" text="Richtig"/>
-                <TableColumn fx:id="sIncorrectColumn" text="Falsch"/>
-            </columns>
-        </TableView>
-        <Button text="Zurück zum Menü" onAction="#backToMenu"/>
+        <BarChart fx:id="comparisonChart" prefHeight="200">
+            <xAxis><CategoryAxis /></xAxis>
+            <yAxis><NumberAxis /></yAxis>
+        </BarChart>
+        <Button text="Zurück zum Menü" onAction="#backToMenu" />
     </VBox>
 </AnchorPane>

--- a/src/ScoreBoard/ScoreBoardController.java
+++ b/src/ScoreBoard/ScoreBoardController.java
@@ -4,118 +4,129 @@ import Utils.SceneLoader.SceneLoader;
 import Utils.StageAwareController;
 import Utils.UserSys.UserSys;
 import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
+import javafx.scene.chart.BarChart;
+import javafx.scene.chart.XYChart;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Label;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
-import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.control.TextField;
 
 import java.net.URL;
+import java.util.Comparator;
+import java.util.List;
 import java.util.ResourceBundle;
+import java.util.stream.Collectors;
 
 /**
- * Controller für die Highscore-Übersicht.
+ * Displays vocabulary statistics using bar charts.
  */
 public class ScoreBoardController extends StageAwareController implements Initializable {
-    private  class StatsRow {
-        private final String list;
-        private final int correct;
-        private final int incorrect;
-
-        public StatsRow(String list, int correct, int incorrect) {
-            this.list = list;
-            this.correct = correct;
-            this.incorrect = incorrect;
-        }
     @FXML
-    private TableView<StatsRow> allTable;
+    private BarChart<String, Number> overallChart;
     @FXML
-    private TableColumn<StatsRow, String> listColumn;
-    @FXML
-    private TableColumn<StatsRow, Integer> correctColumn;
-    @FXML
-    private TableColumn<StatsRow, Integer> incorrectColumn;
-
-    @FXML
-    private TableView<StatsRow> singleTable;
-    @FXML
-    private TableColumn<StatsRow, String> sListColumn;
-    @FXML
-    private TableColumn<StatsRow, Integer> sCorrectColumn;
-    @FXML
-    private TableColumn<StatsRow, Integer> sIncorrectColumn;
-
+    private BarChart<String, Number> comparisonChart;
     @FXML
     private ChoiceBox<String> listChoiceBox;
     @FXML
+    private ChoiceBox<String> modeChoiceBox;
+    @FXML
+    private TextField countField;
+    @FXML
     private Label userLabel;
+
+    private static String lastSessionList;
+
+    /** Called by the trainer when a round finished. */
+    public static void setLastSessionList(String listId) {
+        lastSessionList = listId;
+    }
 
     @Override
     public void initialize(URL url, ResourceBundle resourceBundle) {
-        listColumn.setCellValueFactory(new PropertyValueFactory<>("list"));
-        correctColumn.setCellValueFactory(new PropertyValueFactory<>("correct"));
-        incorrectColumn.setCellValueFactory(new PropertyValueFactory<>("incorrect"));
-
-        sListColumn.setCellValueFactory(new PropertyValueFactory<>("list"));
-        sCorrectColumn.setCellValueFactory(new PropertyValueFactory<>("correct"));
-        sIncorrectColumn.setCellValueFactory(new PropertyValueFactory<>("incorrect"));
-
         userLabel.setText("Statistik für " + UserSys.getCurrentUser());
-        fillAllTable();
+        modeChoiceBox.setItems(FXCollections.observableArrayList("User", "List"));
+        modeChoiceBox.setValue("User");
+        countField.setText("5");
         fillChoiceBox();
-        listChoiceBox.getSelectionModel().selectedItemProperty().addListener((obs,o,n) -> updateSingleTable(n));
+        fillOverallChart();
+        updateComparisonChart();
+
+        listChoiceBox.getSelectionModel().selectedItemProperty().addListener((o, oldVal, newVal) -> updateComparisonChart());
+        modeChoiceBox.getSelectionModel().selectedItemProperty().addListener((o, oldVal, newVal) -> updateComparisonChart());
     }
 
-    /**
-     * Fill table with stats of the current user for all available lists.
-     */
-    private void fillAllTable() {
-        ObservableList<StatsRow> rows = FXCollections.observableArrayList();
-        String user = UserSys.getCurrentUser();
-        for (String list : UserSys.getAllListIds(user)) {
-            var stats = UserSys.getUser(user).getStats(list);
-            rows.add(new StatsRow(list,
-                    stats.getCorrect(),
-                    stats.getIncorrect()));
-        }
-        allTable.setItems(rows);
-    }
-
-    /**
-     * Populate the choice box with all list ids of the user.
-     */
     private void fillChoiceBox() {
-        listChoiceBox.getItems().clear();
         String user = UserSys.getCurrentUser();
-        listChoiceBox.getItems().addAll(UserSys.getAllListIds(user));
+        listChoiceBox.setItems(FXCollections.observableArrayList(UserSys.getAllListIds(user)));
         if (!listChoiceBox.getItems().isEmpty()) {
-            listChoiceBox.getSelectionModel().selectFirst();
-            updateSingleTable(listChoiceBox.getValue());
+            if (lastSessionList != null && listChoiceBox.getItems().contains(lastSessionList)) {
+                listChoiceBox.setValue(lastSessionList);
+            } else {
+                listChoiceBox.getSelectionModel().selectFirst();
+            }
         }
     }
 
-    /**
-     * Update the second table with stats only for the selected list.
-     */
-    private void updateSingleTable(String listId) {
-        if (listId == null) return;
-        ObservableList<StatsRow> rows = FXCollections.observableArrayList();
+    private void fillOverallChart() {
+        overallChart.getData().clear();
+        XYChart.Series<String, Number> correctSeries = new XYChart.Series<>();
+        XYChart.Series<String, Number> incorrectSeries = new XYChart.Series<>();
         String user = UserSys.getCurrentUser();
-        var stats = UserSys.getUser(user).getStats(listId);
-        rows.add(new StatsRow(listId,
-                stats.getCorrect(),
-                stats.getIncorrect()));
-        singleTable.setItems(rows);
+        if (lastSessionList != null) {
+            var stats = UserSys.getUser(user).getStats(lastSessionList);
+            correctSeries.getData().add(new XYChart.Data<>(lastSessionList, stats.getCorrect()));
+            incorrectSeries.getData().add(new XYChart.Data<>(lastSessionList, stats.getIncorrect()));
+        } else {
+            for (String list : UserSys.getAllListIds(user)) {
+                var stats = UserSys.getUser(user).getStats(list);
+                correctSeries.getData().add(new XYChart.Data<>(list, stats.getCorrect()));
+                incorrectSeries.getData().add(new XYChart.Data<>(list, stats.getIncorrect()));
+            }
+        }
+        correctSeries.setName("Richtig");
+        incorrectSeries.setName("Falsch");
+        overallChart.getData().addAll(correctSeries, incorrectSeries);
     }
 
-    /**
-     * Zurück zum Hauptmenü.
-     */
+    @FXML
+    private void updateComparisonChart() {
+        comparisonChart.getData().clear();
+        String listId = listChoiceBox.getValue();
+        if (listId == null) return;
+        String mode = modeChoiceBox.getValue();
+        int count = 5;
+        try {
+            count = Integer.parseInt(countField.getText());
+        } catch (NumberFormatException ignored) {}
+
+        if ("User".equals(mode)) {
+            XYChart.Series<String, Number> series = new XYChart.Series<>();
+            series.setName("Richtig");
+            List<XYChart.Data<String, Number>> data = UserSys.getAllUserNames().stream()
+                    .map(name -> new XYChart.Data<>(name, UserSys.getUser(name).getStats(listId).getCorrect()))
+                    .sorted(Comparator.comparingInt(d -> -d.getYValue().intValue()))
+                    .limit(count)
+                    .collect(Collectors.toList());
+            series.getData().addAll(data);
+            comparisonChart.getData().add(series);
+        } else {
+            XYChart.Series<String, Number> series = new XYChart.Series<>();
+            series.setName("Richtig");
+            String user = UserSys.getCurrentUser();
+            List<XYChart.Data<String, Number>> data = UserSys.getAllListIds(user).stream()
+                    .map(l -> new XYChart.Data<>(l, UserSys.getUser(user).getStats(l).getCorrect()))
+                    .sorted(Comparator.comparingInt(d -> -d.getYValue().intValue()))
+                    .limit(count)
+                    .collect(Collectors.toList());
+            series.getData().addAll(data);
+            comparisonChart.getData().add(series);
+        }
+    }
+
     @FXML
     private void backToMenu() {
+        lastSessionList = null;
         SceneLoader.load(stage, "/MainMenu/mainMenu.fxml");
     }
 }

--- a/src/Trainer/TrainerController.java
+++ b/src/Trainer/TrainerController.java
@@ -230,6 +230,7 @@ public class TrainerController extends StageAwareController {
     }
 
     private void finishTraining() {
+        ScoreBoard.ScoreBoardController.setLastSessionList(listId);
         if (stage != null) {
             SceneLoader.load(stage, "/ScoreBoard/ScoreBoard.fxml");
         } else {


### PR DESCRIPTION
## Summary
- redo scoreboard using bar charts
- display global or last round data for the current user
- add comparison chart between users or lists with configurable item count
- wire trainer and main menu to set the scoreboard context

## Testing
- `javac @sources.txt` *(fails: package javafx.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861cb5983c08326a4af40034dc271d4