### PR TITLE
Add prototype ConnectTrainer gamemode

### DIFF
--- a/src/ConnectTrainer/ConnectTrainer.css
+++ b/src/ConnectTrainer/ConnectTrainer.css
@@ -1,0 +1,5 @@
+.vocab-box {
+    -fx-background-color: lightblue;
+    -fx-border-color: gray;
+    -fx-alignment: center;
+}

--- a/src/ConnectTrainer/ConnectTrainer.fxml
+++ b/src/ConnectTrainer/ConnectTrainer.fxml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<AnchorPane xmlns="http://javafx.com/javafx/17.0.12"
+            xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="ConnectTrainer.ConnectTrainerController">
+    <children>
+        <Pane fx:id="drawPane" prefWidth="600" prefHeight="400"
+              AnchorPane.topAnchor="40" AnchorPane.leftAnchor="20"
+              AnchorPane.rightAnchor="20" AnchorPane.bottomAnchor="20">
+            <children>
+                <Label fx:id="leftLabel" layoutX="50" layoutY="180" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="rightLabel" layoutX="400" layoutY="180" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+            </children>
+        </Pane>
+        <Button fx:id="backButton" text="Zurück" layoutX="20" layoutY="10" onAction="#handleBack" />
+    </children>
+</AnchorPane>

--- a/src/ConnectTrainer/ConnectTrainerController.java
+++ b/src/ConnectTrainer/ConnectTrainerController.java
@@ -1,0 +1,84 @@
+package ConnectTrainer;
+
+import Trainer.TrainerModel;
+import Utils.SceneLoader.SceneLoader;
+import Utils.StageAwareController;
+import Utils.UserSys.UserSys;
+import javafx.fxml.FXML;
+import javafx.geometry.Bounds;
+import javafx.geometry.Point2D;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Pane;
+import javafx.scene.shape.Line;
+
+public class ConnectTrainerController extends StageAwareController {
+    @FXML
+    private Pane drawPane;
+    @FXML
+    private Label leftLabel;
+    @FXML
+    private Label rightLabel;
+
+    private Line currentLine;
+
+    @FXML
+    private void initialize() {
+        String listId = UserSys.getPreference("vocabFile", "defaultvocab.json");
+        String mode = UserSys.getPreference("vocabMode", "Deutsch zu Englisch");
+        TrainerModel model = new TrainerModel();
+        model.LoadJSONtoDataObj(listId);
+        String id = model.getAllIds().iterator().next();
+        String[] langPair = model.getLangPairForMode(mode);
+        if (langPair == null) {
+            langPair = new String[]{"de", "en"};
+        }
+        leftLabel.setText(model.get(id, langPair[0]));
+        rightLabel.setText(model.get(id, langPair[1]));
+
+        setupDrag(leftLabel, rightLabel);
+        setupDrag(rightLabel, leftLabel);
+    }
+
+    private void setupDrag(Label start, Label other) {
+        start.setOnMousePressed(e -> {
+            Point2D startPoint = getCenter(start);
+            currentLine = new Line(startPoint.getX(), startPoint.getY(), startPoint.getX(), startPoint.getY());
+            drawPane.getChildren().add(currentLine);
+        });
+        start.setOnMouseDragged(e -> {
+            if (currentLine != null) {
+                Point2D p = sceneToPane(e.getSceneX(), e.getSceneY());
+                currentLine.setEndX(p.getX());
+                currentLine.setEndY(p.getY());
+            }
+        });
+        start.setOnMouseReleased(e -> {
+            if (currentLine != null) {
+                Bounds b = other.localToScene(other.getBoundsInLocal());
+                if (b.contains(e.getSceneX(), e.getSceneY())) {
+                    Point2D endPoint = getCenter(other);
+                    currentLine.setEndX(endPoint.getX());
+                    currentLine.setEndY(endPoint.getY());
+                } else {
+                    drawPane.getChildren().remove(currentLine);
+                }
+                currentLine = null;
+            }
+        });
+    }
+
+    private Point2D getCenter(Label node) {
+        Bounds bounds = node.getBoundsInParent();
+        return new Point2D(bounds.getMinX() + bounds.getWidth() / 2,
+                bounds.getMinY() + bounds.getHeight() / 2);
+    }
+
+    private Point2D sceneToPane(double x, double y) {
+        return drawPane.sceneToLocal(x, y);
+    }
+
+    @FXML
+    private void handleBack() {
+        SceneLoader.load(stage, "/MainMenu/mainMenu.fxml");
+    }
+}

--- a/src/MainMenu/MainMenuController.java
+++ b/src/MainMenu/MainMenuController.java
@@ -46,6 +46,11 @@ public class MainMenuController extends StageAwareController {
         SceneLoader.load("/Trainer/Trainer.fxml");
     }
 
+    @FXML
+    public void openConnectTrainer() {
+        SceneLoader.load("/ConnectTrainer/ConnectTrainer.fxml");
+    }
+
     public void openSettings() {
         SceneLoader.load("/Settings/Settings.fxml");
     }

--- a/src/MainMenu/mainMenu.fxml
+++ b/src/MainMenu/mainMenu.fxml
@@ -36,6 +36,7 @@
             </VBox>
 
             <Button maxWidth="Infinity" onAction="#openTrainer" text="Vokabeltrainer starten" />
+            <Button maxWidth="Infinity" onAction="#openConnectTrainer" text="Verbindungsmodus" />
             <Button maxWidth="Infinity" onAction="#openUserManagement" text="Benutzer verwalten" />
             <Button maxWidth="Infinity" onAction="#openScoreBoard" text="Highscore" />
             <Button fx:id="exitButton" maxWidth="Infinity" onAction="#handleExit" text="Beenden" />


### PR DESCRIPTION
## Summary
- introduce a new `ConnectTrainer` package with controller, FXML and CSS
- allow dragging a line between two vocab labels
- add button in MainMenu to open this gamemode

## Testing
- `javac --module-path /usr/share/openjfx/lib --add-modules javafx.controls,javafx.fxml,javafx.media -classpath lib/json-20250517.jar -d build_classes @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68659f8c54288326a0cd487680cff07b