### PR TITLE
Add confetti effect and admin trigger

### DIFF
--- a/src/MainMenu/MainMenuController.java
+++ b/src/MainMenu/MainMenuController.java
@@ -10,6 +10,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.VBox;
+import javafx.scene.layout.Pane;
+import Utils.Confetti.Confetti;
 
 import java.util.List;
 
@@ -21,6 +23,8 @@ public class MainMenuController extends StageAwareController {
     public Label mainLabel;
     public Button searchButton;
     public Button addButton;
+    @FXML
+    private Button confettiButton;
 
     @FXML
     private TextField userField;
@@ -139,6 +143,13 @@ public class MainMenuController extends StageAwareController {
                 UserSys.saveToJson();
                 List<String> matches = UserSys.searchUsers(input);
 
+                if ("@confetti".equalsIgnoreCase(input)) {
+                    Confetti.show((Pane) userField.getScene().getRoot());
+                    statusLabel.setText("Konfetti!");
+                    statusLabel.setStyle("-fx-text-fill: green;");
+                    return;
+                }
+
                 if (!matches.isEmpty()) {
                     setUserField(matches.getFirst());
                     statusLabel.setText("Benutzer '" + matches.getFirst() + "' gefunden und ausgewählt.");
@@ -166,4 +177,12 @@ public class MainMenuController extends StageAwareController {
     }
 
 
+    
+
+    @FXML
+    private void adminConfetti() {
+        if (userField != null) {
+            Confetti.show((Pane) userField.getScene().getRoot());
+        }
+    }
 }

--- a/src/MainMenu/mainMenu.fxml
+++ b/src/MainMenu/mainMenu.fxml
@@ -40,6 +40,7 @@
             <Button maxWidth="Infinity" onAction="#openUserManagement" text="Benutzer verwalten" />
             <Button maxWidth="Infinity" onAction="#openScoreBoard" text="Highscore" />
             <Button fx:id="exitButton" maxWidth="Infinity" onAction="#handleExit" text="Beenden" />
+            <Button fx:id="confettiButton" maxWidth="Infinity" onAction="#adminConfetti" text="🎉" />
          <BorderPane.margin>
             <Insets bottom="50.0" right="100.0" />
          </BorderPane.margin>

--- a/src/Trainer/Trainer.fxml
+++ b/src/Trainer/Trainer.fxml
@@ -7,7 +7,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<AnchorPane xmlns="http://javafx.com/javafx/17.0.12"
+<AnchorPane fx:id="rootPane" xmlns="http://javafx.com/javafx/17.0.12"
             xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="Trainer.TrainerController">
 
@@ -28,5 +28,6 @@
             <Button fx:id="finishButton" text="Vorzeitig beenden" />
         </HBox>
     </VBox>
+    <Pane fx:id="confettiPane" mouseTransparent="true" />
 
 </AnchorPane>

--- a/src/Trainer/TrainerController.java
+++ b/src/Trainer/TrainerController.java
@@ -4,6 +4,7 @@ import Utils.SceneLoader.SceneLoader;
 import Utils.Sound.SoundModel;
 import Utils.StageAwareController;
 import Utils.UserSys.UserSys;
+import Utils.Confetti.Confetti;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.geometry.Pos;
@@ -12,6 +13,8 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
 
 import java.util.ArrayList;
@@ -33,6 +36,10 @@ public class TrainerController extends StageAwareController {
     private Button finishButton;
     @FXML
     private Label pointsLabel;
+    @FXML
+    private Pane confettiPane;
+    @FXML
+    private AnchorPane rootPane;
 
     private TrainerModel model;
     private String listId = "defaultvocab.json";
@@ -209,6 +216,10 @@ public class TrainerController extends StageAwareController {
             soundModel.playSound("src/Utils/Sound/teilweise.mp3");
         } else {
             soundModel.playSound("src/Utils/Sound/falsch.mp3");
+        }
+
+        if (allCorrect) {
+            Confetti.show(confettiPane != null ? confettiPane : rootPane);
         }
 
 

--- a/src/Utils/Confetti/Confetti.java
+++ b/src/Utils/Confetti/Confetti.java
@@ -1,0 +1,44 @@
+package Utils.Confetti;
+
+import javafx.animation.FadeTransition;
+import javafx.animation.TranslateTransition;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
+import javafx.util.Duration;
+
+import java.util.Random;
+
+public class Confetti {
+    private static final Random random = new Random();
+
+    public static void show(Pane pane) {
+        if (pane == null) return;
+        double width = pane.getWidth();
+        double height = pane.getHeight();
+        // fallback if width/height are zero (not yet laid out)
+        if (width == 0) width = 800; // default
+        if (height == 0) height = 600;
+        for (int i = 0; i < 60; i++) {
+            Circle c = new Circle(5, randomColor());
+            c.setCenterX(random.nextDouble() * width);
+            c.setCenterY(-10);
+            pane.getChildren().add(c);
+
+            TranslateTransition tt = new TranslateTransition(Duration.seconds(3 + random.nextDouble()), c);
+            tt.setFromY(-10);
+            tt.setToY(height + 10);
+            tt.setOnFinished(e -> pane.getChildren().remove(c));
+            tt.play();
+
+            FadeTransition ft = new FadeTransition(Duration.seconds(3 + random.nextDouble()), c);
+            ft.setFromValue(1.0);
+            ft.setToValue(0.0);
+            ft.play();
+        }
+    }
+
+    private static Color randomColor() {
+        return Color.hsb(random.nextDouble() * 360, 1.0, 1.0);
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable `Confetti` effect
- show the animation in the trainer when all answers are correct
- allow admins to trigger the animation via `@confetti` search command
- add a confetti button on the main menu

## Testing
- `javac src/Utils/Confetti/Confetti.java` *(fails: package javafx... does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6865a0cf553c832694322cca7a96e238