### PR TITLE
Improve ConnectTrainer layout

### DIFF
--- a/src/ConnectTrainer/ConnectTrainer.css
+++ b/src/ConnectTrainer/ConnectTrainer.css
@@ -3,3 +3,12 @@
     -fx-border-color: gray;
     -fx-alignment: center;
 }
+
+.connector-box {
+    -fx-background-color: lightgray;
+    -fx-border-color: darkgray;
+    -fx-min-width: 30;
+    -fx-min-height: 30;
+    -fx-alignment: center;
+    -fx-background-radius: 5;
+}

--- a/src/ConnectTrainer/ConnectTrainer.fxml
+++ b/src/ConnectTrainer/ConnectTrainer.fxml
@@ -9,8 +9,23 @@
               AnchorPane.topAnchor="40" AnchorPane.leftAnchor="20"
               AnchorPane.rightAnchor="20" AnchorPane.bottomAnchor="20">
             <children>
-                <Label fx:id="leftLabel" layoutX="50" layoutY="180" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
-                <Label fx:id="rightLabel" layoutX="400" layoutY="180" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="leftLabel1" layoutX="50" layoutY="40" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="leftLabel2" layoutX="50" layoutY="100" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="leftLabel3" layoutX="50" layoutY="160" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="leftLabel4" layoutX="50" layoutY="220" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="leftLabel5" layoutX="50" layoutY="280" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+
+                <Label fx:id="rightLabel1" layoutX="400" layoutY="40" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="rightLabel2" layoutX="400" layoutY="100" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="rightLabel3" layoutX="400" layoutY="160" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="rightLabel4" layoutX="400" layoutY="220" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="rightLabel5" layoutX="400" layoutY="280" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+
+                <Label fx:id="connector1" layoutX="275" layoutY="40" styleClass="connector-box" />
+                <Label fx:id="connector2" layoutX="275" layoutY="100" styleClass="connector-box" />
+                <Label fx:id="connector3" layoutX="275" layoutY="160" styleClass="connector-box" />
+                <Label fx:id="connector4" layoutX="275" layoutY="220" styleClass="connector-box" />
+                <Label fx:id="connector5" layoutX="275" layoutY="280" styleClass="connector-box" />
             </children>
         </Pane>
         <Button fx:id="backButton" text="Zurück" layoutX="20" layoutY="10" onAction="#handleBack" />

--- a/src/ConnectTrainer/ConnectTrainerController.java
+++ b/src/ConnectTrainer/ConnectTrainerController.java
@@ -46,7 +46,9 @@ public class ConnectTrainerController extends StageAwareController {
         for (int i = 0; i < 5 && i < ids.size(); i++) {
             String id = ids.get(i);
             leftLabels.get(i).setText(model.get(id, langPair[0]));
+            leftLabels.get(i).setId("left_" + id);
             rightLabels.get(i).setText(model.get(id, langPair[1]));
+            rightLabels.get(i).setId("right_" + id);
             setupDrag(leftLabels.get(i), rightLabels.get(i));
             setupDrag(rightLabels.get(i), leftLabels.get(i));
         }


### PR DESCRIPTION
## Summary
- extend ConnectTrainer.fxml to show five vocab boxes per side and a line connector in the middle
- style connectors in ConnectTrainer.css
- assign unique IDs to each vocab label in ConnectTrainerController

## Testing
- `javac @sources.txt` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6867f6a4817c832697450feebee400f5