### PR TITLE
Fix Connect Trainer layout

### DIFF
--- a/src/ConnectTrainer/ConnectTrainer.css
+++ b/src/ConnectTrainer/ConnectTrainer.css
@@ -7,8 +7,8 @@
 .connector-box {
     -fx-background-color: lightgray;
     -fx-border-color: darkgray;
-    -fx-min-width: 30;
-    -fx-min-height: 30;
+    -fx-min-width: 20;
+    -fx-min-height: 20;
     -fx-alignment: center;
     -fx-background-radius: 5;
 }

--- a/src/ConnectTrainer/ConnectTrainer.fxml
+++ b/src/ConnectTrainer/ConnectTrainer.fxml
@@ -9,23 +9,27 @@
               AnchorPane.topAnchor="40" AnchorPane.leftAnchor="20"
               AnchorPane.rightAnchor="20" AnchorPane.bottomAnchor="20">
             <children>
+                <Label fx:id="leftConnector1" layoutX="30" layoutY="50" prefWidth="20" prefHeight="20" styleClass="connector-box" />
                 <Label fx:id="leftLabel1" layoutX="50" layoutY="40" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="leftConnector2" layoutX="30" layoutY="110" prefWidth="20" prefHeight="20" styleClass="connector-box" />
                 <Label fx:id="leftLabel2" layoutX="50" layoutY="100" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="leftConnector3" layoutX="30" layoutY="170" prefWidth="20" prefHeight="20" styleClass="connector-box" />
                 <Label fx:id="leftLabel3" layoutX="50" layoutY="160" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="leftConnector4" layoutX="30" layoutY="230" prefWidth="20" prefHeight="20" styleClass="connector-box" />
                 <Label fx:id="leftLabel4" layoutX="50" layoutY="220" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="leftConnector5" layoutX="30" layoutY="290" prefWidth="20" prefHeight="20" styleClass="connector-box" />
                 <Label fx:id="leftLabel5" layoutX="50" layoutY="280" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
 
                 <Label fx:id="rightLabel1" layoutX="400" layoutY="40" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="rightConnector1" layoutX="560" layoutY="50" prefWidth="20" prefHeight="20" styleClass="connector-box" />
                 <Label fx:id="rightLabel2" layoutX="400" layoutY="100" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="rightConnector2" layoutX="560" layoutY="110" prefWidth="20" prefHeight="20" styleClass="connector-box" />
                 <Label fx:id="rightLabel3" layoutX="400" layoutY="160" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="rightConnector3" layoutX="560" layoutY="170" prefWidth="20" prefHeight="20" styleClass="connector-box" />
                 <Label fx:id="rightLabel4" layoutX="400" layoutY="220" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
+                <Label fx:id="rightConnector4" layoutX="560" layoutY="230" prefWidth="20" prefHeight="20" styleClass="connector-box" />
                 <Label fx:id="rightLabel5" layoutX="400" layoutY="280" prefWidth="150" prefHeight="40" styleClass="vocab-box" />
-
-                <Label fx:id="connector1" layoutX="275" layoutY="40" styleClass="connector-box" />
-                <Label fx:id="connector2" layoutX="275" layoutY="100" styleClass="connector-box" />
-                <Label fx:id="connector3" layoutX="275" layoutY="160" styleClass="connector-box" />
-                <Label fx:id="connector4" layoutX="275" layoutY="220" styleClass="connector-box" />
-                <Label fx:id="connector5" layoutX="275" layoutY="280" styleClass="connector-box" />
+                <Label fx:id="rightConnector5" layoutX="560" layoutY="290" prefWidth="20" prefHeight="20" styleClass="connector-box" />
             </children>
         </Pane>
         <Button fx:id="backButton" text="Zurück" layoutX="20" layoutY="10" onAction="#handleBack" />

--- a/src/ConnectTrainer/ConnectTrainerController.java
+++ b/src/ConnectTrainer/ConnectTrainerController.java
@@ -8,6 +8,7 @@ import javafx.fxml.FXML;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.scene.control.Label;
+import javafx.scene.paint.Color;
 import javafx.scene.layout.Pane;
 import javafx.scene.shape.Line;
 
@@ -22,6 +23,10 @@ public class ConnectTrainerController extends StageAwareController {
     private Label leftLabel1, leftLabel2, leftLabel3, leftLabel4, leftLabel5;
     @FXML
     private Label rightLabel1, rightLabel2, rightLabel3, rightLabel4, rightLabel5;
+    @FXML
+    private Label leftConnector1, leftConnector2, leftConnector3, leftConnector4, leftConnector5;
+    @FXML
+    private Label rightConnector1, rightConnector2, rightConnector3, rightConnector4, rightConnector5;
 
     private final List<Line> lines = new ArrayList<>();
     private Line currentLine;
@@ -42,6 +47,8 @@ public class ConnectTrainerController extends StageAwareController {
 
         List<Label> leftLabels = List.of(leftLabel1, leftLabel2, leftLabel3, leftLabel4, leftLabel5);
         List<Label> rightLabels = List.of(rightLabel1, rightLabel2, rightLabel3, rightLabel4, rightLabel5);
+        List<Label> leftConnectors = List.of(leftConnector1, leftConnector2, leftConnector3, leftConnector4, leftConnector5);
+        List<Label> rightConnectors = List.of(rightConnector1, rightConnector2, rightConnector3, rightConnector4, rightConnector5);
 
         for (int i = 0; i < 5 && i < ids.size(); i++) {
             String id = ids.get(i);
@@ -49,15 +56,16 @@ public class ConnectTrainerController extends StageAwareController {
             leftLabels.get(i).setId("left_" + id);
             rightLabels.get(i).setText(model.get(id, langPair[1]));
             rightLabels.get(i).setId("right_" + id);
-            setupDrag(leftLabels.get(i), rightLabels.get(i));
-            setupDrag(rightLabels.get(i), leftLabels.get(i));
+            setupDrag(leftConnectors.get(i), rightConnectors);
+            setupDrag(rightConnectors.get(i), leftConnectors);
         }
     }
 
-    private void setupDrag(Label start, Label target) {
+    private void setupDrag(Label start, List<Label> targets) {
         start.setOnMousePressed(e -> {
             Point2D startPoint = getCenter(start);
             currentLine = new Line(startPoint.getX(), startPoint.getY(), startPoint.getX(), startPoint.getY());
+            currentLine.setStroke(randomColor());
             drawPane.getChildren().add(currentLine);
         });
 
@@ -71,18 +79,32 @@ public class ConnectTrainerController extends StageAwareController {
 
         start.setOnMouseReleased(e -> {
             if (currentLine != null) {
-                Bounds b = target.localToScene(target.getBoundsInLocal());
-                if (b.contains(e.getSceneX(), e.getSceneY())) {
-                    Point2D endPoint = getCenter(target);
-                    currentLine.setEndX(endPoint.getX());
-                    currentLine.setEndY(endPoint.getY());
-                } else {
-                    drawPane.getChildren().remove(currentLine);
+                boolean placed = false;
+                for (Label target : targets) {
+                    Bounds b = target.localToScene(target.getBoundsInLocal());
+                    if (b.contains(e.getSceneX(), e.getSceneY())) {
+                        Point2D endPoint = getCenter(target);
+                        currentLine.setEndX(endPoint.getX());
+                        currentLine.setEndY(endPoint.getY());
+                        placed = true;
+                        break;
+                    }
                 }
-                lines.add(currentLine);
+                if (!placed) {
+                    drawPane.getChildren().remove(currentLine);
+                } else {
+                    lines.add(currentLine);
+                }
                 currentLine = null;
             }
         });
+    }
+
+    private Color randomColor() {
+        double hue = Math.random() * 360;
+        double saturation = 0.5 + Math.random() * 0.3; // avoid extremes
+        double brightness = 0.5 + Math.random() * 0.2;
+        return Color.hsb(hue, saturation, brightness);
     }
 
     private Point2D getCenter(Label node) {


### PR DESCRIPTION
## Summary
- add connector boxes directly next to each vocab item
- randomize line colors and allow any vocab to connect with another
- shrink connector boxes for a cleaner look

## Testing
- `javac --module-path /usr/share/openjfx/lib --add-modules javafx.controls,javafx.fxml -cp lib/json-20250517.jar -d out $(find src -name '*.java')` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f89a3234832698de7cc81e6b0816