### PR TITLE
Fix ConnectTrainer layout and interactions

### DIFF
--- a/src/ConnectTrainer/ConnectTrainer.fxml
+++ b/src/ConnectTrainer/ConnectTrainer.fxml
@@ -12,6 +12,11 @@
         <Button fx:id="backButton" text="Zurück" onAction="#handleBack"
                 AnchorPane.topAnchor="10" AnchorPane.leftAnchor="10"/>
 
+        <!-- Pane for connecting lines -->
+        <Pane fx:id="drawPane" mouseTransparent="true" pickOnBounds="false"
+              AnchorPane.topAnchor="50" AnchorPane.bottomAnchor="10"
+              AnchorPane.leftAnchor="10" AnchorPane.rightAnchor="10" />
+
         <!-- Main Layout -->
         <GridPane fx:id="mainGrid"
                   AnchorPane.topAnchor="50" AnchorPane.bottomAnchor="10"

--- a/src/ConnectTrainer/ConnectTrainerController.java
+++ b/src/ConnectTrainer/ConnectTrainerController.java
@@ -83,7 +83,8 @@ public class ConnectTrainerController extends StageAwareController {
                 return false;
             });
 
-            Point2D startPoint = getCenter(connector);
+            Point2D startScene = getCenter(connector);
+            Point2D startPoint = sceneToPane(startScene.getX(), startScene.getY());
             currentLine = new Line(startPoint.getX(), startPoint.getY(), startPoint.getX(), startPoint.getY());
             currentLine.setStroke(randomColor());
             currentLine.setUserData(connector);
@@ -116,7 +117,7 @@ public class ConnectTrainerController extends StageAwareController {
     }
 
     private Label findConnectorAt(Point2D scenePoint, Label ignore) {
-        for (javafx.scene.Node node : drawPane.lookupAll(".connector-box")) {
+        for (javafx.scene.Node node : mainGrid.lookupAll(".connector-box")) {
             if (!(node instanceof Label conn) || conn == ignore) continue;
             Bounds bounds = conn.localToScene(conn.getBoundsInLocal());
             if (bounds.contains(scenePoint)) return conn;


### PR DESCRIPTION
## Summary
- restore `drawPane` in `ConnectTrainer.fxml`
- adjust `ConnectTrainerController` to place lines correctly and to search for connector boxes in the grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6867fe5e8c888326b488a0606d1706f3