### PR TITLE
Fix ConnectTrainer drawing pane and connector layout

### DIFF
--- a/src/ConnectTrainer/ConnectTrainer.fxml
+++ b/src/ConnectTrainer/ConnectTrainer.fxml
@@ -5,6 +5,7 @@
 
 <AnchorPane xmlns="http://javafx.com/javafx/17.0.12"
             xmlns:fx="http://javafx.com/fxml/1"
+            fx:id="drawPane"
             fx:controller="ConnectTrainer.ConnectTrainerController">
 
     <children>

--- a/src/ConnectTrainer/ConnectTrainerController.java
+++ b/src/ConnectTrainer/ConnectTrainerController.java
@@ -10,8 +10,9 @@ import javafx.geometry.Point2D;
 import javafx.scene.control.Label;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.GridPane;
-import javafx.scene.layout.Pane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import javafx.geometry.Pos;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Line;
 
@@ -52,19 +53,25 @@ public class ConnectTrainerController extends StageAwareController {
             Label connLeft = new Label();
             connLeft.setPrefSize(20, 20);
             connLeft.getStyleClass().add("connector-box");
+            connLeft.setTranslateX(-10); // overlap half with label
 
-            VBox leftRow = new VBox(5, vocabLeft, connLeft);
+            HBox leftRow = new HBox(vocabLeft, connLeft);
+            leftRow.setSpacing(0);
+            leftRow.setAlignment(Pos.CENTER_RIGHT);
             leftBox.getChildren().add(leftRow);
 
             // RIGHT
             Label connRight = new Label();
             connRight.setPrefSize(20, 20);
             connRight.getStyleClass().add("connector-box");
+            connRight.setTranslateX(10); // overlap half with label
 
             Label vocabRight = new Label(model.get(id, langPair[1]));
             vocabRight.getStyleClass().add("vocab-box");
 
-            VBox rightRow = new VBox(5, connRight, vocabRight);
+            HBox rightRow = new HBox(connRight, vocabRight);
+            rightRow.setSpacing(0);
+            rightRow.setAlignment(Pos.CENTER_LEFT);
             rightBox.getChildren().add(rightRow);
 
             setupDrag(connLeft);


### PR DESCRIPTION
## Summary
- add `fx:id` to the root pane so drag lines can be drawn
- place connector boxes beside the vocab labels and overlap half the label

## Testing
- `javac -d build/classes --module-path /usr/share/openjfx/lib --add-modules javafx.controls,javafx.fxml -cp lib/json-20250517.jar $files && echo "compile success"`


------
https://chatgpt.com/codex/tasks/task_e_68680025ad788326ace37bd3a9a10c46