### PR TITLE
Implement fullscreen and responsive layout

### DIFF
--- a/src/responsive.css
+++ b/src/responsive.css
@@ -1,0 +1,3 @@
+.responsive-wrapper {
+    -fx-alignment: center;
+}


### PR DESCRIPTION
## Summary
- wrap loaded scenes in a `StackPane` for centered layout
- load new `responsive.css`
- add fullscreen stage handling except for settings scene
- dynamically pad the wrapper to keep 80–90% size

## Testing
- `javac @sources.txt` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68680a71ac308326ad160e5295a55a5f