### PR TITLE
Improve responsive fullscreen behavior

### DIFF
--- a/src/Utils/SceneLoader/SceneLoader.java
+++ b/src/Utils/SceneLoader/SceneLoader.java
@@ -60,6 +60,7 @@ public class SceneLoader {
             wrapper.getStyleClass().add("responsive-wrapper");
             Scene scene = new Scene(wrapper);
             applyResponsivePadding(wrapper, stage, fxmlPath);
+            applyResponsiveSize(wrapper, stage, fxmlPath);
 
             // CSS-Dateipfad berechnen: gleicher Pfad wie FXML, aber mit .css statt .fxml
             String cssPath = fxmlPath.replace(".fxml", ".css");
@@ -84,9 +85,11 @@ public class SceneLoader {
                 scene.getStylesheets().add(responsiveUrl.toExternalForm());
             }
 
+            boolean isSettings = fxmlPath.contains("Settings");
             stage.setScene(scene);
-            stage.setFullScreen(!fxmlPath.contains("Settings"));
-            stage.setMaximized(true);
+            stage.setFullScreen(false); // avoid movie style fullscreen
+            stage.setMaximized(!isSettings);
+            stage.setResizable(true);
             stage.show();
 
         } catch (IOException e) {
@@ -107,6 +110,25 @@ public class SceneLoader {
         stage.widthProperty().addListener(listener);
         stage.heightProperty().addListener(listener);
         // initial call
+        listener.changed(null, null, null);
+    }
+
+    private static void applyResponsiveSize(StackPane wrapper, Stage stage, String fxmlPath) {
+        if (fxmlPath.contains("Settings")) {
+            return;
+        }
+        ChangeListener<Number> listener = (obs, o, n) -> {
+            double w = stage.getWidth();
+            double h = stage.getHeight();
+            wrapper.setMinWidth(w * 0.7);
+            wrapper.setMinHeight(h * 0.7);
+            wrapper.setPrefWidth(w * 0.8);
+            wrapper.setPrefHeight(h * 0.8);
+            wrapper.setMaxWidth(w * 0.9);
+            wrapper.setMaxHeight(h * 0.9);
+        };
+        stage.widthProperty().addListener(listener);
+        stage.heightProperty().addListener(listener);
         listener.changed(null, null, null);
     }
 

--- a/src/responsive.css
+++ b/src/responsive.css
@@ -1,3 +1,5 @@
 .responsive-wrapper {
     -fx-alignment: center;
+    -fx-fill-width: true;
+    -fx-fill-height: true;
 }


### PR DESCRIPTION
## Summary
- center and scale scenes using new `applyResponsiveSize`
- avoid fullscreen movie mode and maximize normal scenes
- ensure resizable stages
- tweak responsive CSS

## Testing
- `javac -d out -cp lib/json-20250517.jar @sources.txt` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68680c1f5bcc8326af7d28becac69b56