### PR TITLE
Improve UI responsiveness

### DIFF
--- a/src/MainMenu/mainMenu.fxml
+++ b/src/MainMenu/mainMenu.fxml
@@ -18,7 +18,7 @@
                 <Insets bottom="20" left="20" right="20" top="20" />
             </padding>
 
-            <Label fx:id="mainLabel" maxWidth="Infinity" text="Vokabeltrainer">
+            <Label fx:id="mainLabel" maxWidth="Infinity" wrapText="true" text="Vokabeltrainer">
                 <font>
                     <Font size="28.0" />
                 </font>
@@ -32,7 +32,7 @@
                         <Button fx:id="addButton" maxWidth="Infinity" onAction="#handleCreateUser" text="+" />
                     </VBox>
                 </HBox>
-                <Label fx:id="statusLabel" maxWidth="Infinity" />
+                <Label fx:id="statusLabel" maxWidth="Infinity" wrapText="true" />
             </VBox>
 
             <Button maxWidth="Infinity" onAction="#openTrainer" text="Vokabeltrainer starten" />

--- a/src/ScoreBoard/ScoreBoard.fxml
+++ b/src/ScoreBoard/ScoreBoard.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.chart.*?>
 <AnchorPane xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="ScoreBoard.ScoreBoardController">
     <VBox spacing="10" AnchorPane.topAnchor="10" AnchorPane.leftAnchor="10" AnchorPane.rightAnchor="10" AnchorPane.bottomAnchor="10">
-        <Label fx:id="userLabel" text="Statistik" />
+        <Label fx:id="userLabel" text="Statistik" wrapText="true" />
         <BarChart fx:id="overallChart" prefHeight="200">
             <xAxis><CategoryAxis label="Liste"/></xAxis>
             <yAxis><NumberAxis label="Anzahl"/></yAxis>

--- a/src/Settings/Settings.fxml
+++ b/src/Settings/Settings.fxml
@@ -32,7 +32,7 @@
          </padding></Label>
       <CheckBox fx:id="darkModeToggle" text="Dark Mode" />
    </VBox>
-   <Label fx:id="mainLable" layoutX="197.0" layoutY="38.0" text="Einstellungen">
+   <Label fx:id="mainLable" layoutX="197.0" layoutY="38.0" text="Einstellungen" wrapText="true">
       <font>
          <Font size="18.0" />
       </font>

--- a/src/Trainer/Trainer.fxml
+++ b/src/Trainer/Trainer.fxml
@@ -17,7 +17,7 @@
           AnchorPane.rightAnchor="20" AnchorPane.bottomAnchor="20">
 
         <!-- Anzeige der aktuellen Punkte -->
-        <Label fx:id="pointsLabel" text="Punkte: 0" />
+        <Label fx:id="pointsLabel" text="Punkte: 0" wrapText="true" />
 
         <!-- Dynamischer Vokabel-Container -->
         <VBox fx:id="vocabBox" spacing="10.0" />

--- a/src/UserManagement/UserManagement.fxml
+++ b/src/UserManagement/UserManagement.fxml
@@ -7,7 +7,7 @@
             fx:controller="UserManagement.UserManagementController">
     <VBox spacing="10" AnchorPane.topAnchor="10" AnchorPane.leftAnchor="10" AnchorPane.rightAnchor="10"
           AnchorPane.bottomAnchor="10">
-        <Label text="Benutzerverwaltung"/>
+        <Label text="Benutzerverwaltung" wrapText="true"/>
         <HBox spacing="5">
             <TextField fx:id="newUserField" promptText="Name"/>
             <Button text="Erstellen" onAction="#createUser"/>

--- a/src/Utils/SceneLoader/SceneLoader.java
+++ b/src/Utils/SceneLoader/SceneLoader.java
@@ -120,12 +120,14 @@ public class SceneLoader {
         ChangeListener<Number> listener = (obs, o, n) -> {
             double w = stage.getWidth();
             double h = stage.getHeight();
-            wrapper.setMinWidth(w * 0.7);
-            wrapper.setMinHeight(h * 0.7);
-            wrapper.setPrefWidth(w * 0.8);
-            wrapper.setPrefHeight(h * 0.8);
-            wrapper.setMaxWidth(w * 0.9);
-            wrapper.setMaxHeight(h * 0.9);
+            double targetW = w * 0.8;
+            double targetH = h * 0.8;
+            wrapper.setMinWidth(targetW);
+            wrapper.setMinHeight(targetH);
+            wrapper.setPrefWidth(targetW);
+            wrapper.setPrefHeight(targetH);
+            wrapper.setMaxWidth(targetW);
+            wrapper.setMaxHeight(targetH);
         };
         stage.widthProperty().addListener(listener);
         stage.heightProperty().addListener(listener);

--- a/src/responsive.css
+++ b/src/responsive.css
@@ -3,3 +3,19 @@
     -fx-fill-width: true;
     -fx-fill-height: true;
 }
+
+/* allow text elements to wrap and use ellipsis when space becomes
+   too small instead of shrinking indefinitely */
+.responsive-wrapper .label,
+.responsive-wrapper .button {
+    -fx-wrap-text: true;
+    -fx-text-overrun: word-ellipsis;
+}
+
+/* slightly larger default controls for better readability */
+.responsive-wrapper .button,
+.responsive-wrapper .text-field,
+.responsive-wrapper .choice-box,
+.responsive-wrapper .list-view {
+    -fx-min-height: 40px;
+}


### PR DESCRIPTION
## Summary
- ensure 80% stage coverage for all scenes
- add responsive text behaviour in `responsive.css`
- allow labels in FXML to wrap text when needed

## Testing
- `javac @sources.txt` *(fails: package javafx.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680d6f780c83268a85f90eca32185b