### PR TITLE
Improve layout responsiveness

### DIFF
--- a/src/Utils/SceneLoader/SceneLoader.java
+++ b/src/Utils/SceneLoader/SceneLoader.java
@@ -60,7 +60,7 @@ public class SceneLoader {
             wrapper.getStyleClass().add("responsive-wrapper");
             Scene scene = new Scene(wrapper);
             applyResponsivePadding(wrapper, stage, fxmlPath);
-            applyResponsiveSize(wrapper, stage, fxmlPath);
+            applyResponsiveSize(wrapper, content, stage, fxmlPath);
 
             // CSS-Dateipfad berechnen: gleicher Pfad wie FXML, aber mit .css statt .fxml
             String cssPath = fxmlPath.replace(".fxml", ".css");
@@ -87,7 +87,7 @@ public class SceneLoader {
 
             boolean isSettings = fxmlPath.contains("Settings");
             stage.setScene(scene);
-            stage.setFullScreen(false); // avoid movie style fullscreen
+            stage.setFullScreen(!isSettings);
             stage.setMaximized(!isSettings);
             stage.setResizable(true);
             stage.show();
@@ -102,10 +102,7 @@ public class SceneLoader {
             return;
         }
         ChangeListener<Number> listener = (obs, o, n) -> {
-            double w = stage.getWidth();
-            double h = stage.getHeight();
-            double ratio = (w < 800 || h < 600) ? 0.05 : 0.1;
-            wrapper.setPadding(new Insets(h * ratio, w * ratio, h * ratio, w * ratio));
+            wrapper.setPadding(Insets.EMPTY);
         };
         stage.widthProperty().addListener(listener);
         stage.heightProperty().addListener(listener);
@@ -113,7 +110,7 @@ public class SceneLoader {
         listener.changed(null, null, null);
     }
 
-    private static void applyResponsiveSize(StackPane wrapper, Stage stage, String fxmlPath) {
+    private static void applyResponsiveSize(StackPane wrapper, Parent content, Stage stage, String fxmlPath) {
         if (fxmlPath.contains("Settings")) {
             return;
         }
@@ -128,6 +125,9 @@ public class SceneLoader {
             wrapper.setPrefHeight(targetH);
             wrapper.setMaxWidth(targetW);
             wrapper.setMaxHeight(targetH);
+            double scale = Math.min(targetW / 800.0, targetH / 600.0);
+            content.setScaleX(scale);
+            content.setScaleY(scale);
         };
         stage.widthProperty().addListener(listener);
         stage.heightProperty().addListener(listener);

--- a/src/responsive.css
+++ b/src/responsive.css
@@ -17,5 +17,5 @@
 .responsive-wrapper .text-field,
 .responsive-wrapper .choice-box,
 .responsive-wrapper .list-view {
-    -fx-min-height: 40px;
+    -fx-min-height: 2em;
 }


### PR DESCRIPTION
## Summary
- resize buttons responsively with `em` units
- remove extra padding around scenes
- scale content based on the window size
- enable real fullscreen in trainer scenes

## Testing
- `javac -cp lib/json-20250517.jar -d out/production $(cat sources.txt)` *(fails: package javafx...)*)

------
https://chatgpt.com/codex/tasks/task_e_68680ed4de1c832693f7e000dc578c7b