### PR TITLE
Refactor connect trainer into MVC and clean imports

### DIFF
--- a/src/ConnectTrainer/ConnectTrainerController.java
+++ b/src/ConnectTrainer/ConnectTrainerController.java
@@ -1,24 +1,27 @@
 package ConnectTrainer;
 
-import Trainer.TrainerModel;
 import Utils.SceneLoader.SceneLoader;
 import Utils.StageAwareController;
 import Utils.UserSys.UserSys;
+import ConnectTrainer.ConnectTrainerModel;
 import javafx.fxml.FXML;
 import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.geometry.Point2D;
+import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
-import javafx.geometry.Pos;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Line;
 import javafx.stage.Window;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ConnectTrainerController extends StageAwareController {
 
@@ -30,25 +33,17 @@ public class ConnectTrainerController extends StageAwareController {
     private final List<Line> lines = new ArrayList<>();
     private final Map<Line, Label[]> lineEndpoints = new HashMap<>();
     private Line currentLine;
+    private final ConnectTrainerModel model = new ConnectTrainerModel();
 
     @FXML
     private void initialize() {
         String listId = UserSys.getPreference("vocabFile", "defaultvocab.json");
         String mode = UserSys.getPreference("vocabMode", "Deutsch zu Englisch");
 
-        TrainerModel model = new TrainerModel();
-        model.LoadJSONtoDataObj(listId);
+        model.loadData(listId, mode);
 
-        String[] langPair = model.getLangPairForMode(mode);
-        if (langPair == null) langPair = new String[]{"de", "en"};
-
-        List<String> ids = new ArrayList<>(model.getAllIds());
-        Collections.shuffle(ids);
-
-        for (int i = 0; i < 5 && i < ids.size(); i++) {
-            String id = ids.get(i);
-
-            Label vocabLeft = new Label(model.get(id, langPair[0]));
+        for (ConnectTrainerModel.VocabPair pair : model.getRandomPairs(5)) {
+            Label vocabLeft = new Label(pair.left);
             vocabLeft.getStyleClass().add("vocab-box");
             VBox.setMargin(vocabLeft, new Insets(5));
 
@@ -68,7 +63,7 @@ public class ConnectTrainerController extends StageAwareController {
             connRight.getStyleClass().add("connector-box");
             connRight.setTranslateX(10);
 
-            Label vocabRight = new Label(model.get(id, langPair[1]));
+            Label vocabRight = new Label(pair.right);
             vocabRight.getStyleClass().add("vocab-box");
             VBox.setMargin(vocabRight, new Insets(5));
 

--- a/src/ConnectTrainer/ConnectTrainerModel.java
+++ b/src/ConnectTrainer/ConnectTrainerModel.java
@@ -1,0 +1,57 @@
+package ConnectTrainer;
+
+import Trainer.TrainerModel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Model for the ConnectTrainer. It loads vocabulary pairs and provides
+ * random pairs for the controller.
+ */
+public class ConnectTrainerModel {
+
+    public static class VocabPair {
+        public final String left;
+        public final String right;
+        public VocabPair(String left, String right) {
+            this.left = left;
+            this.right = right;
+        }
+    }
+
+    private final TrainerModel trainerModel = new TrainerModel();
+    private final List<String> ids = new ArrayList<>();
+    private String[] langPair = {"de", "en"};
+
+    /** Load vocabulary file and prepare language pair according to mode. */
+    public void loadData(String vocabFile, String mode) {
+        trainerModel.LoadJSONtoDataObj(vocabFile);
+        String[] pair = trainerModel.getLangPairForMode(mode);
+        if (pair != null) {
+            langPair = pair;
+        }
+        ids.clear();
+        ids.addAll(trainerModel.getAllIds());
+        Collections.shuffle(ids);
+    }
+
+    /**
+     * Return up to {@code count} random pairs from the loaded vocabulary list.
+     */
+    public List<VocabPair> getRandomPairs(int count) {
+        List<VocabPair> result = new ArrayList<>();
+        for (int i = 0; i < count && i < ids.size(); i++) {
+            String id = ids.get(i);
+            String left = trainerModel.get(id, langPair[0]);
+            String right = trainerModel.get(id, langPair[1]);
+            result.add(new VocabPair(left, right));
+        }
+        return result;
+    }
+
+    public String[] getLangPair() {
+        return langPair.clone();
+    }
+}

--- a/src/Trainer/TrainerModel.java
+++ b/src/Trainer/TrainerModel.java
@@ -8,7 +8,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Verwaltet die Vokabellisten des Trainers. Beim Erzeugen werden die

--- a/src/Trainer/old/TrainerView_old.java
+++ b/src/Trainer/old/TrainerView_old.java
@@ -8,7 +8,8 @@ import javafx.scene.layout.VBox;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class TrainerView_old {
 

--- a/src/Utils/UserScore_old/UserSystem.java
+++ b/src/Utils/UserScore_old/UserSystem.java
@@ -1,6 +1,11 @@
 package Utils.UserScore_old;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/Utils/UserSys/UserSys.java
+++ b/src/Utils/UserSys/UserSys.java
@@ -4,11 +4,20 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class UserSys {
 


### PR DESCRIPTION
## Summary
- move connect trainer vocabulary logic to new `ConnectTrainerModel`
- simplify `ConnectTrainerController` and use the model
- replace wildcard imports across the codebase
- minor cleanup of legacy classes

## Testing
- `javac @sources.txt -classpath lib/json-20250517.jar` *(fails: package javafx.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680f2acfe08326adc530f2cd1ba93f