### PR TITLE
Fix fullscreen behavior and center trainer

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -e
 FX_PATH="${JAVA_FX_LIB:-/usr/share/openjfx/lib}"
 FX_MODULES="javafx.controls,javafx.fxml,javafx.media"
-find src -name '*.java' > sources.txt
+find src -name '*.java' ! -path '*/old/*' > sources.txt
 mkdir -p build
 javac --module-path "$FX_PATH" --add-modules "$FX_MODULES" -classpath lib/json-20250517.jar -d build @sources.txt
 

--- a/src/Trainer/Trainer.fxml
+++ b/src/Trainer/Trainer.fxml
@@ -12,7 +12,7 @@
             xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="Trainer.TrainerController">
 
-    <VBox layoutX="20.0" layoutY="20.0" spacing="20.0"
+    <VBox alignment="CENTER" layoutX="20.0" layoutY="20.0" spacing="20.0"
           AnchorPane.topAnchor="20" AnchorPane.leftAnchor="20"
           AnchorPane.rightAnchor="20" AnchorPane.bottomAnchor="20">
 

--- a/src/Trainer/TrainerController.java
+++ b/src/Trainer/TrainerController.java
@@ -135,9 +135,7 @@ public class TrainerController extends StageAwareController {
             vocabBox.getChildren().add(box);
         }
 
-        if (stage != null) {
-            Platform.runLater(stage::sizeToScene);
-        }
+        // Keep the window size from the previous scene
     }
 
     private String langName(String code) {

--- a/src/Utils/SceneLoader/SceneLoader.java
+++ b/src/Utils/SceneLoader/SceneLoader.java
@@ -86,10 +86,8 @@ public class SceneLoader {
                 scene.getStylesheets().add(responsiveUrl.toExternalForm());
             }
 
-            boolean isSettings = fxmlPath.contains("Settings");
             stage.setScene(scene);
-            stage.setFullScreen(!isSettings);
-            stage.setMaximized(!isSettings);
+            // keep current window state (fullscreen or not)
             stage.setResizable(true);
             stage.show();
 


### PR DESCRIPTION
## Summary
- keep previous window size on scene changes
- exclude unused `old` sources from build
- center trainer content

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_686815a5be5c8326b504aa74d406a7d6