### PR TITLE
Fix UI layout

### DIFF
--- a/src/MainMenu/MainMenuController.java
+++ b/src/MainMenu/MainMenuController.java
@@ -105,7 +105,7 @@ public class MainMenuController extends StageAwareController {
     private void toggleSideMenu() {
         boolean isVisible = sideMenu.isVisible();
         sideMenu.setVisible(!isVisible);
-       // sideMenu.setManaged(!isVisible);
+        sideMenu.setManaged(!isVisible);
     }
 
     @FXML

--- a/src/MainMenu/mainMenu.css
+++ b/src/MainMenu/mainMenu.css
@@ -8,8 +8,6 @@
 .label {
     -fx-text-fill: #2c3e50;
     -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 2, 0, 0, 1);
-    -fx-max-width: Infinity;
-    -fx-max-height: Infinity;
 }
 
 #mainLabel {
@@ -19,8 +17,6 @@
     -fx-font-family: "Arial Black";
     -fx-padding: 10 0 20 0;
     -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.3), 4, 0, 0, 2);
-    -fx-max-width: Infinity;
-    -fx-max-height: Infinity;
     -fx-alignment: center;
     -fx-text-alignment: center;
     -fx-wrap-text: true;
@@ -29,8 +25,6 @@
 .border-pane {
     -fx-pref-width: USE_COMPUTED_SIZE;
     -fx-pref-height: USE_COMPUTED_SIZE;
-    -fx-max-width: Infinity;
-    -fx-max-height: Infinity;
     -fx-alignment: center;
     -fx-padding: 20;
 }
@@ -46,8 +40,8 @@
     -fx-background-radius: 5;
     -fx-min-width: 50;
     -fx-min-height: 35;
-    -fx-max-width: Infinity;
-    -fx-max-height: Infinity;
+    -fx-pref-width: 50;
+    -fx-pref-height: 35;
 
 }
 
@@ -60,8 +54,8 @@
     -fx-padding: 8;
     -fx-prompt-text-fill: #95a5a6;
     -fx-min-height: 35;
-    -fx-max-width: Infinity;
-    -fx-max-height: Infinity;
+    -fx-pref-width: 300;
+    -fx-pref-height: 35;
 }
 
 /* Hauptmenü Buttons */
@@ -70,12 +64,12 @@ VBox > Button {
     -fx-text-fill: white;
     -fx-font-size: 14px;
     -fx-padding: 10 20;
-    -fx-min-width: 200;
+    -fx-min-width: 150;
+    -fx-pref-width: 200;
     -fx-min-height: 40;
     -fx-background-radius: 5;
     -fx-cursor: hand;
-    -fx-max-width: Infinity;
-    -fx-max-height: Infinity;
+    -fx-pref-height: 40;
     -fx-alignment: center;
     -fx-content-display: center;
     -fx-wrap-text: true;
@@ -88,10 +82,10 @@ VBox > Button {
     -fx-alignment: center-left;
     -fx-padding: 10 15;
     -fx-min-width: 150;
+    -fx-pref-width: 150;
     -fx-min-height: 35;
     -fx-effect: none;
-    -fx-max-width: Infinity;
-    -fx-max-height: Infinity;
+    -fx-pref-height: 35;
     -fx-translate-y: 5;
 }
 
@@ -110,17 +104,17 @@ VBox > Button {
     -fx-border-radius: 3;
     -fx-cursor: hand;
     -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 3, 0, 0, 1);
-    -fx-max-width: Infinity;
-    -fx-max-height: Infinity;
+    -fx-pref-width: 50;
+    -fx-pref-height: 25;
 }
 
 /* Beenden-Button */
 #exitButton {
     -fx-background-color: #e74c3c;
-    -fx-min-width: 200;
+    -fx-min-width: 150;
+    -fx-pref-width: 200;
     -fx-min-height: 40;
-    -fx-max-width: Infinity;
-    -fx-max-height: Infinity;
+    -fx-pref-height: 40;
 }
 
 /* Hover und Pressed Effekte */

--- a/src/MainMenu/mainMenu.fxml
+++ b/src/MainMenu/mainMenu.fxml
@@ -8,7 +8,7 @@
 <BorderPane xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="MainMenu.MainMenuController">
     <top>
         <HBox>
-            <Button fx:id="burgerMenu" maxWidth="Infinity" onAction="#toggleSideMenu" text="≡" />
+            <Button fx:id="burgerMenu" onAction="#toggleSideMenu" text="≡" />
         </HBox>
     </top>
 
@@ -18,7 +18,7 @@
                 <Insets bottom="20" left="20" right="20" top="20" />
             </padding>
 
-            <Label fx:id="mainLabel" maxWidth="Infinity" wrapText="true" text="Vokabeltrainer">
+            <Label fx:id="mainLabel" wrapText="true" text="Vokabeltrainer">
                 <font>
                     <Font size="28.0" />
                 </font>
@@ -28,18 +28,18 @@
                 <HBox alignment="CENTER" spacing="10">
                     <TextField fx:id="userField" maxWidth="300" promptText="Benutzername" />
                     <VBox alignment="CENTER_LEFT" spacing="5">
-                        <Button fx:id="searchButton" maxWidth="Infinity" onAction="#handleSearchUser" text="🔍" />
-                        <Button fx:id="addButton" maxWidth="Infinity" onAction="#handleCreateUser" text="+" />
+                        <Button fx:id="searchButton" onAction="#handleSearchUser" text="🔍" />
+                        <Button fx:id="addButton" onAction="#handleCreateUser" text="+" />
                     </VBox>
                 </HBox>
-                <Label fx:id="statusLabel" maxWidth="Infinity" wrapText="true" />
+                <Label fx:id="statusLabel" wrapText="true" />
             </VBox>
 
-            <Button maxWidth="Infinity" onAction="#openTrainer" text="Vokabeltrainer starten" />
+            <Button onAction="#openTrainer" text="Vokabeltrainer starten" />
 <!--            <Button maxWidth="Infinity" onAction="#openConnectTrainer" text="Verbindungsmodus" />-->
-            <Button maxWidth="Infinity" onAction="#openUserManagement" text="Benutzer verwalten" />
-            <Button maxWidth="Infinity" onAction="#openScoreBoard" text="Highscore" />
-            <Button fx:id="exitButton" maxWidth="Infinity" onAction="#handleExit" text="Beenden" />
+            <Button onAction="#openUserManagement" text="Benutzer verwalten" />
+            <Button onAction="#openScoreBoard" text="Highscore" />
+            <Button fx:id="exitButton" onAction="#handleExit" text="Beenden" />
 <!--            <Button fx:id="confettiButton" maxWidth="Infinity" onAction="#adminConfetti" text="🎉" />-->
          <BorderPane.margin>
             <Insets bottom="50.0" right="100.0" />
@@ -48,8 +48,8 @@
     </center>
 
     <left>
-        <VBox fx:id="sideMenu" visible="false">
-            <Button fx:id="buttonSettings" maxWidth="Infinity" onAction="#openSettings" text="Einstellungen" />
+        <VBox fx:id="sideMenu" visible="false" managed="false">
+            <Button fx:id="buttonSettings" onAction="#openSettings" text="Einstellungen" />
         </VBox>
     </left>
 </BorderPane>

--- a/src/Settings/Settings.fxml
+++ b/src/Settings/Settings.fxml
@@ -20,9 +20,9 @@
           </VBox.margin>
        </ChoiceBox>
       <Label text="Confetti" />
-       <Button fx:id="confettibutton" maxWidth="Infinity" onAction="#adminConfetti" text="🎉" />
+       <Button fx:id="confettibutton" onAction="#adminConfetti" text="🎉" />
       <Label prefHeight="17.0" prefWidth="272.0" text="Secret Game Mode (Alpha Connect Vocabluar)" />
-       <Button maxWidth="Infinity" onAction="#openConnectTrainer" text="Verbindungsmodus" />
+       <Button onAction="#openConnectTrainer" text="Verbindungsmodus" />
        <Label fx:id="vDark" text="Erscheinungsbild:">
           <VBox.margin>
              <Insets />


### PR DESCRIPTION
## Summary
- collapse side menu properly
- stop main menu buttons from stretching
- shrink width for search, add, and exit buttons
- trim wide button markup in settings screen

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_686816f143808326a605914191cdcf7d