### PR TITLE
Improve UI responsiveness

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -67,3 +67,17 @@ input[type="text"] {
     display: block;
     margin-top: 0.5em;
 }
+
+@media (max-width: 700px) {
+    body {
+        flex-direction: column;
+    }
+    #sidebar {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #ccc;
+    }
+    #content {
+        padding: 1em;
+    }
+}

--- a/src/Utils/SceneLoader/SceneLoader.java
+++ b/src/Utils/SceneLoader/SceneLoader.java
@@ -15,6 +15,13 @@ import java.net.URL;
 import Utils.UserSys.UserSys;
 
 public class SceneLoader {
+    /**
+     * Minimum and maximum scale factors applied when resizing scenes. These
+     * bounds prevent extremely small or excessively large UI elements on
+     * unusual window sizes.
+     */
+    private static final double MIN_SCALE = 0.5;
+    private static final double MAX_SCALE = 1.5;
 
     private static class StageManager {
         private static Stage primaryStage;
@@ -125,6 +132,7 @@ public class SceneLoader {
             wrapper.setMaxWidth(targetW);
             wrapper.setMaxHeight(targetH);
             double scale = Math.min(targetW / 800.0, targetH / 600.0);
+            scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale));
             content.setScaleX(scale);
             content.setScaleY(scale);
         };
@@ -139,6 +147,7 @@ public class SceneLoader {
         }
         ChangeListener<Number> listener = (obs, o, n) -> {
             double scale = Math.min(stage.getWidth() / 800.0, stage.getHeight() / 600.0);
+            scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale));
             content.setStyle("-fx-font-size: " + (14 * scale) + "px;");
         };
         stage.widthProperty().addListener(listener);

--- a/src/responsive.css
+++ b/src/responsive.css
@@ -2,6 +2,7 @@
     -fx-alignment: center;
     -fx-fill-width: true;
     -fx-fill-height: true;
+    -fx-padding: 10;
 }
 
 /* allow text elements to wrap and use ellipsis when space becomes
@@ -18,4 +19,5 @@
 .responsive-wrapper .choice-box,
 .responsive-wrapper .list-view {
     -fx-min-height: 2em;
+    -fx-max-width: Infinity;
 }


### PR DESCRIPTION
## Summary
- clamp UI scale factor to keep windows from becoming too small or overly large
- refine responsive wrapper styles
- make docs layout adapt on small screens

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6868187da85083269687e12cdbec7ee8