### PR TITLE
Improve Trainer layout centering

### DIFF
--- a/src/Trainer/Trainer.css
+++ b/src/Trainer/Trainer.css
@@ -12,7 +12,11 @@ VBox {
 
 HBox {
     -fx-spacing: 10;
-    -fx-alignment: CENTER-LEFT;
+    -fx-alignment: CENTER;
+}
+
+#vocabBox {
+    -fx-alignment: CENTER;
 }
 
 /* Label Styling */

--- a/src/Trainer/Trainer.fxml
+++ b/src/Trainer/Trainer.fxml
@@ -3,18 +3,17 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
 <?import javafx.scene.layout.Pane?>
-<AnchorPane fx:id="rootPane" xmlns="http://javafx.com/javafx/17.0.12"
-            xmlns:fx="http://javafx.com/fxml/1"
-            fx:controller="Trainer.TrainerController">
+<StackPane fx:id="rootPane" xmlns="http://javafx.com/javafx/17.0.12"
+           xmlns:fx="http://javafx.com/fxml/1"
+           fx:controller="Trainer.TrainerController"
+           alignment="CENTER">
 
-    <VBox alignment="CENTER" layoutX="20.0" layoutY="20.0" spacing="20.0"
-          AnchorPane.topAnchor="20" AnchorPane.leftAnchor="20"
-          AnchorPane.rightAnchor="20" AnchorPane.bottomAnchor="20">
+    <VBox alignment="CENTER" spacing="20.0">
 
         <!-- Anzeige der aktuellen Punkte -->
         <Label fx:id="pointsLabel" text="Punkte: 0" wrapText="true" />
@@ -31,4 +30,4 @@
     </VBox>
     <Pane fx:id="confettiPane" mouseTransparent="true" />
 
-</AnchorPane>
+</StackPane>

--- a/src/Trainer/TrainerController.java
+++ b/src/Trainer/TrainerController.java
@@ -14,7 +14,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 
 import java.util.ArrayList;
@@ -39,7 +39,7 @@ public class TrainerController extends StageAwareController {
     @FXML
     private Pane confettiPane;
     @FXML
-    private AnchorPane rootPane;
+    private StackPane rootPane;
 
     private TrainerModel model;
     private String listId = "defaultvocab.json";


### PR DESCRIPTION
## Summary
- keep Trainer UI centered using a `StackPane`
- center buttons and vocab list in stylesheet
- update controller to use `StackPane`

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_686819d1ed9483269a4e04d218759514