### PR TITLE
Improve responsive layout for settings view

### DIFF
--- a/src/Settings/Settings.fxml
+++ b/src/Settings/Settings.fxml
@@ -5,44 +5,37 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.*?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Settings.SettingsController">
-   <VBox layoutX="16.0" layoutY="77.0" AnchorPane.bottomAnchor="47.0" AnchorPane.leftAnchor="16.0" AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="77.0">
-       <Label text="Vokabelliste:" />
-       <ChoiceBox fx:id="vocabListBox">
-          <VBox.margin>
-             <Insets />
-          </VBox.margin>
-       </ChoiceBox>
-       <Label text="Vokabelmodus:" />
-       <ChoiceBox fx:id="vocabModeBox">
-          <VBox.margin>
-             <Insets />
-          </VBox.margin>
-       </ChoiceBox>
-      <Label text="Confetti" />
-       <Button fx:id="confettibutton" onAction="#adminConfetti" text="🎉" />
-      <Label prefHeight="17.0" prefWidth="272.0" text="Secret Game Mode (Alpha Connect Vocabluar)" />
-       <Button onAction="#openConnectTrainer" text="Verbindungsmodus" />
-       <Label fx:id="vDark" text="Erscheinungsbild:">
-          <VBox.margin>
-             <Insets />
-          </VBox.margin>
-         <padding>
-            <Insets top="20.0" />
-         </padding></Label>
-      <CheckBox fx:id="darkModeToggle" text="Dark Mode" />
-   </VBox>
-   <Label fx:id="mainLable" layoutX="197.0" layoutY="38.0" text="Einstellungen" wrapText="true">
-      <font>
-         <Font size="18.0" />
-      </font>
-   </Label>
-   <Button fx:id="Button" mnemonicParsing="false" onAction="#openMainMenu" text="←" AnchorPane.leftAnchor="10.0" AnchorPane.topAnchor="10.0">
-      <font>
-         <Font size="14.0" />
-      </font>
-   </Button>
-   <rotationAxis>
-      <Point3D />
-   </rotationAxis>
-</AnchorPane>
+<BorderPane xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="Settings.SettingsController">
+    <top>
+        <HBox spacing="10" alignment="CENTER_LEFT">
+            <Button fx:id="Button" onAction="#openMainMenu" text="←">
+                <font>
+                    <Font size="14.0" />
+                </font>
+            </Button>
+            <Label fx:id="mainLable" text="Einstellungen" wrapText="true">
+                <font>
+                    <Font size="18.0" />
+                </font>
+            </Label>
+        </HBox>
+    </top>
+    <center>
+        <VBox spacing="10" alignment="CENTER" BorderPane.alignment="CENTER">
+            <Label text="Vokabelliste:" />
+            <ChoiceBox fx:id="vocabListBox" />
+            <Label text="Vokabelmodus:" />
+            <ChoiceBox fx:id="vocabModeBox" />
+            <Label text="Confetti" />
+            <Button fx:id="confettibutton" onAction="#adminConfetti" text="🎉" />
+            <Label prefHeight="17.0" prefWidth="272.0" text="Secret Game Mode (Alpha Connect Vocabluar)" />
+            <Button onAction="#openConnectTrainer" text="Verbindungsmodus" />
+            <Label fx:id="vDark" text="Erscheinungsbild:">
+                <padding>
+                    <Insets top="20.0" />
+                </padding>
+            </Label>
+            <CheckBox fx:id="darkModeToggle" text="Dark Mode" />
+        </VBox>
+    </center>
+</BorderPane>

--- a/src/Settings/SettingsController.java
+++ b/src/Settings/SettingsController.java
@@ -24,7 +24,6 @@ public class SettingsController extends StageAwareController implements Initiali
 
     public Label mainLable;
     public Button Button;
-    public Button button;
     public CheckBox darkModeToggle;
     public Label vDark;
     public Button confettibutton;

--- a/src/Utils/SceneLoader/SceneLoader.java
+++ b/src/Utils/SceneLoader/SceneLoader.java
@@ -104,9 +104,6 @@ public class SceneLoader {
     }
 
     private static void applyResponsivePadding(StackPane wrapper, Stage stage, String fxmlPath) {
-        if (fxmlPath.contains("Settings")) {
-            return;
-        }
         ChangeListener<Number> listener = (obs, o, n) -> {
             wrapper.setPadding(Insets.EMPTY);
         };
@@ -117,9 +114,6 @@ public class SceneLoader {
     }
 
     private static void applyResponsiveSize(StackPane wrapper, Parent content, Stage stage, String fxmlPath) {
-        if (fxmlPath.contains("Settings")) {
-            return;
-        }
         ChangeListener<Number> listener = (obs, o, n) -> {
             double w = stage.getWidth();
             double h = stage.getHeight();
@@ -142,9 +136,6 @@ public class SceneLoader {
     }
 
     private static void applyResponsiveFontScale(Parent content, Stage stage, String fxmlPath) {
-        if (fxmlPath.contains("Settings")) {
-            return;
-        }
         ChangeListener<Number> listener = (obs, o, n) -> {
             double scale = Math.min(stage.getWidth() / 800.0, stage.getHeight() / 600.0);
             scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale));


### PR DESCRIPTION
## Summary
- refactor Settings.fxml to use BorderPane based layout
- remove unused controller field
- enable responsive scaling for the settings scene

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68681c60e16c8326ab5cb071601904d2