### PR TITLE
Improve scoreboard responsiveness

### DIFF
--- a/src/ScoreBoard/ScoreBoard.fxml
+++ b/src/ScoreBoard/ScoreBoard.fxml
@@ -5,17 +5,17 @@
 <AnchorPane xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="ScoreBoard.ScoreBoardController">
     <VBox spacing="10" alignment="CENTER" AnchorPane.topAnchor="10" AnchorPane.leftAnchor="10" AnchorPane.rightAnchor="10" AnchorPane.bottomAnchor="10">
         <Label fx:id="userLabel" text="Statistik" wrapText="true" />
-        <BarChart fx:id="overallChart" VBox.vgrow="ALWAYS">
+        <BarChart fx:id="overallChart" VBox.vgrow="ALWAYS" maxWidth="Infinity">
             <xAxis><CategoryAxis label="Liste"/></xAxis>
             <yAxis><NumberAxis label="Anzahl"/></yAxis>
         </BarChart>
-        <HBox spacing="5" alignment="CENTER">
+        <HBox spacing="5" alignment="CENTER" maxWidth="Infinity">
             <ChoiceBox fx:id="listChoiceBox" />
             <ChoiceBox fx:id="modeChoiceBox" />
             <TextField fx:id="countField" prefWidth="60" />
             <Button text="Aktualisieren" onAction="#updateComparisonChart" />
         </HBox>
-        <BarChart fx:id="comparisonChart" VBox.vgrow="ALWAYS">
+        <BarChart fx:id="comparisonChart" VBox.vgrow="ALWAYS" maxWidth="Infinity">
             <xAxis><CategoryAxis /></xAxis>
             <yAxis><NumberAxis /></yAxis>
         </BarChart>

--- a/src/Utils/SceneLoader/SceneLoader.java
+++ b/src/Utils/SceneLoader/SceneLoader.java
@@ -123,8 +123,8 @@ public class SceneLoader {
         ChangeListener<Number> listener = (obs, o, n) -> {
             double w = stage.getWidth();
             double h = stage.getHeight();
-            double targetW = w * 0.8;
-            double targetH = h * 0.8;
+            double targetW = w * 0.9;
+            double targetH = h * 0.9;
             wrapper.setMinWidth(targetW);
             wrapper.setMinHeight(targetH);
             wrapper.setPrefWidth(targetW);


### PR DESCRIPTION
## Summary
- tweak SceneLoader so scenes use 90% of available space
- expand ScoreBoard charts and input row to fill width

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68681d3fb99883268565435cd7931f26