### PR TITLE
Restore burger menu placement

### DIFF
--- a/src/MainMenu/mainMenu.fxml
+++ b/src/MainMenu/mainMenu.fxml
@@ -7,7 +7,7 @@
 
 <BorderPane xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="MainMenu.MainMenuController">
     <top>
-        <HBox>
+        <HBox alignment="CENTER_LEFT">
             <Button fx:id="burgerMenu" onAction="#toggleSideMenu" text="≡" />
         </HBox>
     </top>


### PR DESCRIPTION
## Summary
- left-align the settings burger menu

## Testing
- `bash build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68681e04b5508326bf66d567960d92ab