### PR TITLE
Fix confetti overlay sizing

### DIFF
--- a/src/Trainer/TrainerController.java
+++ b/src/Trainer/TrainerController.java
@@ -86,6 +86,11 @@ public class TrainerController extends StageAwareController {
         nextButton.setOnAction(event -> checkAnswers());
         finishButton.setOnAction(event -> finishTraining());
         backButton.setOnAction(event -> SceneLoader.load(stage, "/MainMenu/mainMenu.fxml"));
+
+        if (confettiPane != null && rootPane != null) {
+            confettiPane.prefWidthProperty().bind(rootPane.widthProperty());
+            confettiPane.prefHeightProperty().bind(rootPane.heightProperty());
+        }
     }
 
     private void loadNextVocabSet() {

--- a/src/Utils/Confetti/Confetti.java
+++ b/src/Utils/Confetti/Confetti.java
@@ -13,12 +13,38 @@ public class Confetti {
     private static final Random random = new Random();
 
     public static void show(Pane pane) {
-        if (pane == null) return;
+        if (pane == null) {
+            return;
+        }
+
+        javafx.application.Platform.runLater(() -> spawnConfetti(pane));
+    }
+
+    private static void spawnConfetti(Pane pane) {
         double width = pane.getWidth();
         double height = pane.getHeight();
-        // fallback if width/height are zero (not yet laid out)
-        if (width == 0) width = 800; // default
-        if (height == 0) height = 600;
+
+        if (width < 2) {
+            width = pane.getLayoutBounds().getWidth();
+        }
+        if (height < 2) {
+            height = pane.getLayoutBounds().getHeight();
+        }
+
+        if (width < 2 && pane.getScene() != null) {
+            width = pane.getScene().getWidth();
+        }
+        if (height < 2 && pane.getScene() != null) {
+            height = pane.getScene().getHeight();
+        }
+
+        if (width < 2) {
+            width = 800;
+        }
+        if (height < 2) {
+            height = 600;
+        }
+
         for (int i = 0; i < 60; i++) {
             Circle c = new Circle(5, randomColor());
             c.setCenterX(random.nextDouble() * width);


### PR DESCRIPTION
## Summary
- ensure the confetti overlay fills the trainer scene

## Testing
- `bash build.sh` *(fails: module not found: javafx)*

------
https://chatgpt.com/codex/tasks/task_e_68682a8a110c832690da85e6046280c5