### PR TITLE
Fix main menu layout

### DIFF
--- a/src/MainMenu/mainMenu.fxml
+++ b/src/MainMenu/mainMenu.fxml
@@ -5,17 +5,19 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.text.*?>
 
-<BorderPane xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="MainMenu.MainMenuController">
-    <top>
-        <HBox alignment="CENTER_LEFT">
-            <Button fx:id="burgerMenu" onAction="#toggleSideMenu" text="≡" />
-        </HBox>
-    </top>
+<VBox xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="MainMenu.MainMenuController" styleClass="border-pane" spacing="10" alignment="TOP_CENTER">
+    <HBox alignment="CENTER_LEFT">
+        <Button fx:id="burgerMenu" onAction="#toggleSideMenu" text="≡" />
+    </HBox>
 
-    <center>
-        <VBox fx:id="centerBox" alignment="CENTER" spacing="20" BorderPane.alignment="CENTER">
+    <HBox alignment="CENTER" spacing="20" VBox.vgrow="ALWAYS">
+        <VBox fx:id="sideMenu" visible="false" managed="false" spacing="10">
+            <Button fx:id="buttonSettings" onAction="#openSettings" text="Einstellungen" />
+        </VBox>
+
+        <VBox fx:id="centerBox" alignment="CENTER" spacing="20" HBox.hgrow="ALWAYS">
             <padding>
-                <Insets bottom="20" left="20" right="20" top="20" />
+                <Insets top="20" right="20" bottom="20" left="20" />
             </padding>
 
             <Label fx:id="mainLabel" wrapText="true" text="Vokabeltrainer">
@@ -42,11 +44,5 @@
             <Button fx:id="exitButton" onAction="#handleExit" text="Beenden" />
 <!--            <Button fx:id="confettiButton" maxWidth="Infinity" onAction="#adminConfetti" text="🎉" />-->
         </VBox>
-    </center>
-
-    <left>
-        <VBox fx:id="sideMenu" visible="false" managed="false">
-            <Button fx:id="buttonSettings" onAction="#openSettings" text="Einstellungen" />
-        </VBox>
-    </left>
-</BorderPane>
+    </HBox>
+</VBox>


### PR DESCRIPTION
## Summary
- simplify MainMenu layout so every element lives inside a single VBox
- keep settings menu in the same box to adjust with window size

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68690cc728e48326a94f0680f4c198a3