### PR TITLE
Fix initial font size calculation

### DIFF
--- a/src/Utils/SceneLoader/SceneLoader.java
+++ b/src/Utils/SceneLoader/SceneLoader.java
@@ -141,7 +141,12 @@ public class SceneLoader {
 
     private static void applyResponsiveFontScale(Parent content, Stage stage, String fxmlPath) {
         ChangeListener<Number> listener = (obs, o, n) -> {
-            double scale = Math.min(stage.getWidth() / 800.0, stage.getHeight() / 600.0);
+            double width = stage.getWidth();
+            double height = stage.getHeight();
+            if (Double.isNaN(width) || Double.isNaN(height)) {
+                return; // ignore until stage has valid dimensions
+            }
+            double scale = Math.min(width / 800.0, height / 600.0);
             scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale));
             content.setStyle("-fx-font-size: " + (14 * scale) + "px;");
         };


### PR DESCRIPTION
## Summary
- ignore responsive font scaling until stage has a valid width and height

## Testing
- `./build.sh`
- `java --module-path /usr/share/openjfx/lib --add-modules javafx.controls,javafx.fxml,javafx.media -cp build:lib/json-20250517.jar Main` *(fails: Unable to open DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68690cb0f3dc83269aca5f0dc44d503d