### PR TITLE
Fix CSS constant usage

### DIFF
--- a/src/MainMenu/mainMenu.css
+++ b/src/MainMenu/mainMenu.css
@@ -23,8 +23,6 @@
 }
 
 .border-pane {
-    -fx-pref-width: USE_COMPUTED_SIZE;
-    -fx-pref-height: USE_COMPUTED_SIZE;
     -fx-alignment: center;
     -fx-padding: 20;
 }


### PR DESCRIPTION
## Summary
- stop using invalid `USE_COMPUTED_SIZE` constant in CSS

## Testing
- `bash build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68690dc5e6a48326837c93ea2fdd4f76